### PR TITLE
ENYO-6331: Fix not to fire `onChange` when changing value in EditableIntegerPicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,8 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/VirtualList.VirtualList`, `moonstone/VirtualList.VirtualGridList` add `data-webos-voice-disabled` prop for disable voice control
-
 - `moonstone/LabeledIconButton` add props to change voice control in IconButton
-
 - `moonstone/VirtualList.VirtualList` to render properly without error when `itemSizes` is given and `dataSize` is 0
-
 - `moonstone/EditableIntegerPicker` to fire onChange events, after changing the value via pointer and 5-way select button
 
 ## [3.2.5] - 2019-11-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/VirtualList.VirtualList` to render properly without error when `itemSizes` is given and `dataSize` is 0
 
+- `moonstone/EditableIntegerPicker` to fire onChange events, after changing the value via pointer and 5-way select button
+
 ## [3.2.5] - 2019-11-14
 
 ### Fixed

--- a/EditableIntegerPicker/EditableIntegerPickerDecorator.js
+++ b/EditableIntegerPicker/EditableIntegerPickerDecorator.js
@@ -151,8 +151,12 @@ const EditableIntegerPickerDecorator = hoc((config, Wrapped) => {	// eslint-disa
 		}
 
 		handleBlur = (ev) => {
+			const value = this.validateValue(parseInt(ev.target.value));
+			if (this.state.value !== value) {
+				forwardChange({value}, this.props);
+			}
 			this.setState({
-				value: this.validateValue(parseInt(ev.target.value)),
+				value,
 				isActive: false
 			}, () => {
 				Spotlight.focus(this.pickerNode);

--- a/EditableIntegerPicker/EditableIntegerPickerDecorator.js
+++ b/EditableIntegerPicker/EditableIntegerPickerDecorator.js
@@ -101,8 +101,8 @@ const EditableIntegerPickerDecorator = hoc((config, Wrapped) => {	// eslint-disa
 					value: this.validateValue(parseInt(ev.value)),
 					noAnimation: false
 				});
+				forwardChange(ev, this.props);
 			}
-			forwardChange(ev, this.props);
 		}
 
 		prepareInput = () => {

--- a/EditableIntegerPicker/tests/EditableIntegerPicker-specs.js
+++ b/EditableIntegerPicker/tests/EditableIntegerPicker-specs.js
@@ -105,6 +105,93 @@ describe('EditableIntegerPicker', () => {
 	);
 
 	test(
+		'should send change event with correct value on blur',
+		() => {
+			const handleChange = jest.fn();
+			const node = document.body.appendChild(document.createElement('div'));
+			const picker = mount(
+				<EditableIntegerPicker onChange={handleChange} min={0} max={100} defaultValue={10} step={1} noAnimation />,
+				{attachTo: node}
+			);
+
+			picker.find('PickerItem').simulate('click', {target: {type: 'click'}});
+
+			const input = node.querySelector('input');
+			picker.find('input').simulate('focus');
+			input.value = 38;
+			input.blur();
+
+			picker.update();
+
+			const expected = 38;
+			const actual = handleChange.mock.calls[0] &&
+				handleChange.mock.calls[0][0] &&
+				handleChange.mock.calls[0][0].value;
+
+			node.parentNode.removeChild(node);
+
+			expect(actual).toBe(expected);
+		}
+	);
+
+	test(
+		'should not send change event with invalid value on blur',
+		() => {
+			const handleChange = jest.fn();
+			const node = document.body.appendChild(document.createElement('div'));
+			const picker = mount(
+				<EditableIntegerPicker onChange={handleChange} min={0} max={100} defaultValue={10} step={1} noAnimation />,
+				{attachTo: node}
+			);
+
+			picker.find('PickerItem').simulate('click', {target: {type: 'click'}});
+
+			const input = node.querySelector('input');
+			picker.find('input').simulate('focus');
+			input.value = 138;
+			input.blur();
+
+			picker.update();
+
+			const expected = 0;
+			const actual = handleChange.mock.calls.length;
+
+			node.parentNode.removeChild(node);
+
+			expect(actual).toBe(expected);
+		}
+	);
+
+	test(
+		'should not send two change event when incrementing from edit mode',
+		() => {
+			const handleChange = jest.fn();
+			const node = document.body.appendChild(document.createElement('div'));
+			const picker = mount(
+				<EditableIntegerPicker onChange={handleChange} min={0} max={100} defaultValue={10} step={1} noAnimation />,
+				{attachTo: node}
+			);
+
+			picker.find('PickerItem').simulate('click', {target: {type: 'click'}});
+
+			const input = node.querySelector('input');
+			picker.find('input').simulate('focus');
+			input.value = 38;
+			increment(picker);
+			input.blur();	// It seems it must be manually blurred
+
+			picker.update();
+
+			const expected = 1;
+			const actual = handleChange.mock.calls.length;
+
+			node.parentNode.removeChild(node);
+
+			expect(actual).toBe(expected);
+		}
+	);
+
+	test(
 		'should enable input field when some number is typed on the picker',
 		() => {
 			const picker = mount(


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
EditableIntegerPicker doesn't fire `onChange` as:
- Cancel input by clicking elsewhere with the mouse pointer while typing
- Press the Enter key while entering a value in VKB.

### Resolution
Since handlerBlur is called in both cases, EditableIntegerPicker fires onChange by comparing the input value with the previous value.


### Additional Considerations

### Links
ENYO-6331

### Comments
Enact-DCO-1.0-Signed-off-by: Baekwoo Jung (baekwoo.jung@lge.com)