### PR TITLE
ENYO-6426: Adjust indentation of the marquee text 

### DIFF
--- a/Panels/Header.module.less
+++ b/Panels/Header.module.less
@@ -29,7 +29,6 @@
 	.decorator .inputHighlight,
 	.title {
 		.moon-header-text();
-		text-indent: 0.05em;  // Fix for characters like `j` being left-truncated because of being too close to the edge
 
 		.spacing {
 			margin-left: 0.05em;


### PR DESCRIPTION
Adjustments to the indentation of text should apply to components that use other marquees as well as Header.
Move the text-indent property from the Header to ui/Marquee. (https://github.com/enactjs/enact/pull/2723)

Enact-DCO-1.0-Signed-off-by: Baekwoo Jung (baekwoo.jung@lge.com)