### PR TITLE
PLAT-105257: Enact repo package.json cleanup

### DIFF
--- a/samples/sampler/package.json
+++ b/samples/sampler/package.json
@@ -16,6 +16,9 @@
     "serve-qa": "start-storybook -p 8080 -c .qa-storybook --ci"
   },
   "license": "Apache-2.0",
+  "enact": {
+  	"theme": "moonstone"
+  },
   "eslintConfig": {
     "extends": "enact/strict",
     "root": true


### PR DESCRIPTION
Explicitly sets `"theme": "moonstone"` to the Sampler `package.json`. This is done both for reference/example and to ensure all current/future agate-specific settings are accessible for storybook. Currently "moonstone" is an implicit fallback default-case when @enact/moonstone is found, but not worth assuming will always be the case.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>