### PR TITLE
PLAT-87184: Remove the iLib <14.4.0 ResBundle cache workaround

### DIFF
--- a/internal/$L/$L.js
+++ b/internal/$L/$L.js
@@ -27,10 +27,7 @@ function createResBundle (options) {
 	let opts = options;
 
 	if (typeof ILIB_MOONSTONE_PATH !== 'undefined') {
-		opts = {
-			basePath: ILIB_MOONSTONE_PATH,
-			...options
-		};
+		opts.basePath = ILIB_MOONSTONE_PATH;
 	}
 
 	if (!opts.onLoad) return;

--- a/internal/$L/$L.js
+++ b/internal/$L/$L.js
@@ -2,7 +2,6 @@
 
 import {getIStringFromBundle} from '@enact/i18n/src/resBundle';
 import ResBundle from 'ilib/lib/ResBundle';
-import ilib from 'ilib';
 
 // The ilib.ResBundle for the active locale used by $L
 let resBundle;

--- a/internal/$L/$L.js
+++ b/internal/$L/$L.js
@@ -7,9 +7,6 @@ import ilib from 'ilib';
 // The ilib.ResBundle for the active locale used by $L
 let resBundle;
 
-// The ilib.data cache object for moonstone ilib usage
-let cache = {};
-
 /**
  * Returns the current ilib.ResBundle
  *
@@ -31,10 +28,6 @@ function createResBundle (options) {
 
 	if (typeof ILIB_MOONSTONE_PATH !== 'undefined') {
 		opts = {
-			loadParams: {
-				// Deprecated; to be removed in future
-				root: ILIB_MOONSTONE_PATH
-			},
 			basePath: ILIB_MOONSTONE_PATH,
 			...options
 		};
@@ -42,28 +35,22 @@ function createResBundle (options) {
 
 	if (!opts.onLoad) return;
 
-	// Swap out app cache for moonstone's
-	const appCache = ilib.data;
-	ilib.data = global.moonstoneILibCache || cache;
-
 	// eslint-disable-next-line no-new
 	new ResBundle({
 		...opts,
 		onLoad: (bundle) => {
-			ilib.data = appCache;
 			opts.onLoad(bundle || null);
 		}
 	});
 }
 
 /**
- * Deletes the current bundle object of strings and clears the cache.
+ * Deletes the current bundle object of strings.
  * @returns {undefined}
  */
 function clearResBundle () {
 	delete ResBundle.strings;
 	delete ResBundle.sysres;
-	cache = {};
 	resBundle = null;
 }
 


### PR DESCRIPTION
* Removes the `ilib.data` hot swapping, since it's no longer needed as long as `basePath` is specified and iLib >=14.4.0 is used.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>