### PR TITLE
PLAT-105393: Support spottable children inside an item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
+- `moonstone/VirtualList.VirtualList`, `moonstone/VirtualList.VirtualGridList` to support navigation with spottable children inside an item
 - `moonstone/VirtualList.VirtualList`, `moonstone/VirtualList.VirtualGridList` add `data-webos-voice-disabled` prop for disable voice control
 - `moonstone/LabeledIconButton` add props to change voice control in IconButton
 - `moonstone/VirtualList.VirtualList` to render properly without error when `itemSizes` is given and `dataSize` is 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/VirtualList.VirtualList`, `moonstone/VirtualList.VirtualGridList` to support navigation with spottable children inside an item
+- `moonstone/VirtualList` to support navigation with spottable children inside an item
 - `moonstone/VirtualList.VirtualList`, `moonstone/VirtualList.VirtualGridList` add `data-webos-voice-disabled` prop for disable voice control
 - `moonstone/LabeledIconButton` add props to change voice control in IconButton
 - `moonstone/VirtualList.VirtualList` to render properly without error when `itemSizes` is given and `dataSize` is 0

--- a/VirtualList/VirtualListBase.js
+++ b/VirtualList/VirtualListBase.js
@@ -28,7 +28,10 @@ const
 	JS = 'JS',
 	Native = 'Native',
 	// using 'bitwise or' for string > number conversion based on performance: https://jsperf.com/convert-string-to-number-techniques/7
-	getNumberValue = (index) => index | 0,
+	getNumberValue = (index) => {
+		let number = +index;
+		return number >= 0 ? number : -1;
+	},
 	nop = () => {},
 	spottableSelector = `.${spottableClass}`;
 
@@ -279,8 +282,8 @@ const VirtualListBaseFactory = (type) => {
 		isScrolledByJump = false
 		isWrappedBy5way = false
 		lastFocusedIndex = null
-		nodeIndexToBeFocused = null
 		preservedIndex = null
+		lastSpotlightDirection = null
 		restoreLastFocused = false
 		uiRefCurrent = null
 
@@ -347,6 +350,19 @@ const VirtualListBaseFactory = (type) => {
 			return all.reduce((focused, node) => {
 				return focused || Number(node.dataset.index) === key && node;
 			}, null);
+		}
+
+		getItemNode = (index) => {
+			const
+				{numOfItems} = this.uiRefCurrent.state,
+				itemContainerNode = this.uiRefCurrent.itemContainerRef.current;
+
+			if (itemContainerNode) {
+				const itemNode = itemContainerNode.children[index % numOfItems];
+				return itemNode && getNumberValue(itemNode.dataset.index) === index ? itemNode : null;
+			}
+
+			return null;
 		}
 
 		findSpottableItem = (indexFrom, indexTo) => {
@@ -428,9 +444,10 @@ const VirtualListBaseFactory = (type) => {
 		 */
 
 		onAcceleratedKeyDown = ({isWrapped, keyCode, nextIndex, repeat, target}) => {
-			const {cbScrollTo, dataSize, spacing, wrap} = this.props;
-			const {dimensionToExtent, primary: {clientSize, gridSize}, scrollPositionTarget} = this.uiRefCurrent;
+			const {cbScrollTo, wrap} = this.props;
+			const {dimensionToExtent, primary: {clientSize, itemSize}, scrollPosition, scrollPositionTarget} = this.uiRefCurrent;
 			const index = getNumberValue(target.dataset.index);
+			const direction = getDirection(keyCode);
 
 			this.isScrolledBy5way = false;
 			this.isScrolledByJump = false;
@@ -440,49 +457,30 @@ const VirtualListBaseFactory = (type) => {
 					row = Math.floor(index / dimensionToExtent),
 					nextRow = Math.floor(nextIndex / dimensionToExtent),
 					start = this.uiRefCurrent.getGridPosition(nextIndex).primaryPosition,
-					end = this.uiRefCurrent.getGridPosition(nextIndex).primaryPosition + gridSize;
-				let isNextItemInView = false;
-
-				if (this.props.itemSizes) {
-					isNextItemInView = this.uiRefCurrent.itemPositions[nextIndex].position >= scrollPositionTarget &&
-						this.uiRefCurrent.getItemBottomPosition(nextIndex) <= scrollPositionTarget + clientSize;
-				} else {
-					const
-						firstFullyVisibleIndex = Math.ceil(scrollPositionTarget / gridSize) * dimensionToExtent,
-						lastFullyVisibleIndex = Math.min(
-							dataSize - 1,
-							Math.floor((scrollPositionTarget + clientSize + spacing) / gridSize) * dimensionToExtent - 1
-						);
-					isNextItemInView = nextIndex >= firstFullyVisibleIndex && nextIndex <= lastFullyVisibleIndex;
-				}
+					end = this.props.itemSizes ? this.uiRefCurrent.getItemBottomPosition(nextIndex) : start + itemSize,
+					startBoundary = (type === Native) ? scrollPosition : scrollPositionTarget,
+					endBoundary = startBoundary + clientSize;
 
 				this.lastFocusedIndex = nextIndex;
 
-				if (isNextItemInView) {
+				if (start >= startBoundary && end <= endBoundary) {
 					// The next item could be still out of viewport. So we need to prevent scrolling into view with `isScrolledBy5way` flag.
 					this.isScrolledBy5way = true;
-					this.focusByIndex(nextIndex);
+					this.focusByIndex(nextIndex, direction);
 					this.isScrolledBy5way = false;
-				} else if (row === nextRow && (start < scrollPositionTarget || end > scrollPositionTarget + clientSize)) {
-					this.focusByIndex(nextIndex);
+				} else if (row === nextRow) {
+					this.focusByIndex(nextIndex, direction);
 				} else {
 					this.isScrolledBy5way = true;
 					this.isWrappedBy5way = isWrapped;
 
-					if (isWrapped && (
+					if (isWrapped && wrap === true && (
 						this.uiRefCurrent.containerRef.current.querySelector(`[data-index='${nextIndex}']${spottableSelector}`) == null
 					)) {
-						if (wrap === true) {
-							this.pause.pause();
-							target.blur();
-						} else {
-							this.focusByIndex(nextIndex);
-						}
-
-						this.nodeIndexToBeFocused = nextIndex;
-					} else {
-						this.focusByIndex(nextIndex);
+						this.pause.pause();
+						target.blur();
 					}
+					this.focusByIndex(nextIndex, direction);
 
 					cbScrollTo({
 						index: nextIndex,
@@ -490,7 +488,7 @@ const VirtualListBaseFactory = (type) => {
 						animate: !(isWrapped && wrap === 'noAnimation')
 					});
 				}
-			} else if (!repeat && Spotlight.move(getDirection(keyCode))) {
+			} else if (!repeat && Spotlight.move(direction)) {
 				SpotlightAccelerator.reset();
 			}
 		}
@@ -505,51 +503,60 @@ const VirtualListBaseFactory = (type) => {
 				if (SpotlightAccelerator.processKey(ev, nop)) {
 					ev.stopPropagation();
 				} else {
-					const {repeat} = ev;
-					const {focusableScrollbar, isHorizontalScrollbarVisible, isVerticalScrollbarVisible, spotlightId} = this.props;
-					const {dimensionToExtent, isPrimaryDirectionVertical} = this.uiRefCurrent;
+					const {spotlightId} = this.props;
 					const targetIndex = target.dataset.index;
-					const isScrollButton = (
-						// if target has an index, it must be an item so can't be a scroll button
+					const isNotItem = (
+						// if target has an index, it must be an item
 						!targetIndex &&
-						// if it lacks an index and is inside the scroller, it must be a button
+						// if it lacks an index and is inside the scroller, we need to handle this
 						target.matches(`[data-spotlight-id="${spotlightId}"] *`)
 					);
-					const index = !isScrollButton ? getNumberValue(targetIndex) : -1;
-					const {isDownKey, isUpKey, isLeftMovement, isRightMovement, isWrapped, nextIndex} = this.getNextIndex({index, keyCode, repeat});
-					const directions = {};
+					const index = !isNotItem ? getNumberValue(targetIndex) : -1;
+					const candidate = getTargetByDirectionFromElement(direction, target);
+					const candidateIndex = candidate && candidate.dataset && getNumberValue(candidate.dataset.index);
 					let isLeaving = false;
-					let isScrollbarVisible;
 
-					if (isPrimaryDirectionVertical) {
-						directions.left = isLeftMovement;
-						directions.right = isRightMovement;
-						directions.up = isUpKey;
-						directions.down = isDownKey;
-						isScrollbarVisible = isVerticalScrollbarVisible;
-					} else {
-						directions.left = isUpKey;
-						directions.right = isDownKey;
-						directions.up = isLeftMovement;
-						directions.down = isRightMovement;
-						isScrollbarVisible = isHorizontalScrollbarVisible;
-					}
+					if (isNotItem) { // if the focused node is not an item
+						if (!ev.currentTarget.contains(candidate)) { // if the candidate is out of a list
+							isLeaving = true;
+						}
+					} else if (candidateIndex !== index) { // the focused node is an item and focus will move out of the item
+						const {repeat} = ev;
+						const {isDownKey, isUpKey, isLeftMovement, isRightMovement, isWrapped, nextIndex} = this.getNextIndex({index, keyCode, repeat});
 
-					if (!isScrollButton) {
-						if (nextIndex >= 0) {
+						if (nextIndex >= 0) { // if the candidate is another item
 							ev.preventDefault();
 							ev.stopPropagation();
 							this.onAcceleratedKeyDown({isWrapped, keyCode, nextIndex, repeat, target});
-						} else {
-							const {dataSize} = this.props;
+						} else { // if the candidate is not found
+							const {dataSize, focusableScrollbar, isHorizontalScrollbarVisible, isVerticalScrollbarVisible} = this.props;
+							const {dimensionToExtent, isPrimaryDirectionVertical} = this.uiRefCurrent;
 							const column = index % dimensionToExtent;
 							const row = (index - column) % dataSize / dimensionToExtent;
-							isLeaving = directions.up && row === 0 ||
+							const directions = {};
+							let isScrollbarVisible;
+
+							if (isPrimaryDirectionVertical) {
+								directions.left = isLeftMovement;
+								directions.right = isRightMovement;
+								directions.up = isUpKey;
+								directions.down = isDownKey;
+								isScrollbarVisible = isVerticalScrollbarVisible;
+							} else {
+								directions.left = isUpKey;
+								directions.right = isDownKey;
+								directions.up = isLeftMovement;
+								directions.down = isRightMovement;
+								isScrollbarVisible = isHorizontalScrollbarVisible;
+							}
+
+							isLeaving =
+								directions.up && row === 0 ||
 								directions.down && row === Math.floor((dataSize - 1) % dataSize / dimensionToExtent) ||
 								directions.left && column === 0 ||
 								directions.right && (!focusableScrollbar || !isScrollbarVisible) && (column === dimensionToExtent - 1 || index === dataSize - 1 && row === 0);
 
-							if (repeat && isLeaving) {
+							if (repeat && isLeaving) { // if focus is about to leave items by holding down an arrowy key
 								ev.preventDefault();
 								ev.stopPropagation();
 							} else if (!isLeaving && Spotlight.move(direction)) {
@@ -562,12 +569,6 @@ const VirtualListBaseFactory = (type) => {
 									this.onAcceleratedKeyDown({keyCode, nextIndex: getNumberValue(nextTargetIndex), repeat, target});
 								}
 							}
-
-						}
-					} else {
-						const possibleTarget = getTargetByDirectionFromElement(direction, target);
-						if (possibleTarget && !ev.currentTarget.contains(possibleTarget)) {
-							isLeaving = true;
 						}
 					}
 
@@ -600,49 +601,46 @@ const VirtualListBaseFactory = (type) => {
 
 		focusOnNode = (node) => {
 			if (node) {
-				Spotlight.focus(node);
+				return Spotlight.focus(node);
 			}
+
+			return false;
 		}
 
-		focusByIndex = (index) => {
-			const item = this.uiRefCurrent.containerRef.current.querySelector(`[data-index='${index}']${spottableSelector}`);
+		focusByIndex = (index, direction) => {
+			const item = this.getItemNode(index);
+			let returnVal = false;
 
 			if (!item && index >= 0 && index < this.props.dataSize) {
 				// Item is valid but since the the dom doesn't exist yet, we set the index to focus after the ongoing update
 				this.preservedIndex = index;
+				this.lastSpotlightDirection = direction;
 				this.restoreLastFocused = true;
 			} else {
+				const
+					current = Spotlight.getCurrent(),
+					candidate = current ? getTargetByDirectionFromElement(direction, current) : item;
+
 				if (this.isWrappedBy5way) {
 					SpotlightAccelerator.reset();
 					this.isWrappedBy5way = false;
 				}
 
 				this.pause.resume();
-				this.focusOnNode(item);
-				this.nodeIndexToBeFocused = null;
+				if (item.contains(candidate)) {
+					returnVal = this.focusOnNode(candidate);
+				} else {
+					returnVal = this.focusOnNode(item);
+				}
 				this.isScrolledByJump = false;
 			}
-		}
 
-		initItemRef = (ref, index) => {
-			if (ref) {
-				if (type === JS) {
-					this.focusByIndex(index);
-				} else {
-					// If focusing the item of VirtuallistNative, `onFocus` in Scrollable will be called.
-					// Then VirtualListNative tries to scroll again differently from VirtualList.
-					// So we would like to skip `focus` handling when focusing the item as a workaround.
-					this.isScrolledByJump = true;
-					this.focusByIndex(index);
-				}
-			}
+			return returnVal;
 		}
 
 		/**
 		 * Manage a placeholder
 		 */
-
-		isNeededScrollingPlaceholder = () => this.nodeIndexToBeFocused != null && Spotlight.isPaused();
 
 		handlePlaceholderFocus = (ev) => {
 			const placeholder = ev.currentTarget;
@@ -652,6 +650,7 @@ const VirtualListBaseFactory = (type) => {
 
 				if (index) {
 					this.preservedIndex = getNumberValue(index);
+					this.lastSpotlightDirection = null;
 					this.restoreLastFocused = true;
 				}
 			}
@@ -695,7 +694,7 @@ const VirtualListBaseFactory = (type) => {
 
 					// try to focus the last focused item
 					this.isScrolledByJump = true;
-					const foundLastFocused = Spotlight.focus(node);
+					const foundLastFocused = this.focusByIndex(this.preservedIndex, this.lastSpotlightDirection);
 					this.isScrolledByJump = false;
 
 					// but if that fails (because it isn't found or is disabled), focus the container so
@@ -720,17 +719,17 @@ const VirtualListBaseFactory = (type) => {
 				offsetToClientEnd = primary.clientSize - primary.itemSize,
 				focusedIndex = getNumberValue(item.getAttribute(dataIndexAttribute));
 
-			if (!isNaN(focusedIndex)) {
+			if (focusedIndex >= 0) {
 				let gridPosition = this.uiRefCurrent.getGridPosition(focusedIndex);
 
 				if (numOfItems > 0 && focusedIndex % numOfItems !== this.lastFocusedIndex % numOfItems) {
-					const node = this.uiRefCurrent.getItemNode(this.lastFocusedIndex);
+					const node = this.getItemNode(this.lastFocusedIndex);
 
 					if (node) {
 						node.blur();
 					}
 				}
-				this.nodeIndexToBeFocused = null;
+
 				this.lastFocusedIndex = focusedIndex;
 
 				if (primary.clientSize >= primary.itemSize) {
@@ -775,10 +774,6 @@ const VirtualListBaseFactory = (type) => {
 
 		getScrollBounds = () => this.uiRefCurrent.getScrollBounds()
 
-		getComponentProps = (index) => (
-			(index === this.nodeIndexToBeFocused) ? {ref: (ref) => this.initItemRef(ref, index)} : {}
-		)
-
 		initUiRef = (ref) => {
 			if (ref) {
 				this.uiRefCurrent = ref;
@@ -787,9 +782,7 @@ const VirtualListBaseFactory = (type) => {
 		}
 
 		render () {
-			const
-				{itemRenderer, itemsRenderer, role, ...rest} = this.props,
-				needsScrollingPlaceholder = this.isNeededScrollingPlaceholder();
+			const {itemRenderer, itemsRenderer, role, ...rest} = this.props;
 
 			delete rest.initUiChildRef;
 			// not used by VirtualList
@@ -801,7 +794,6 @@ const VirtualListBaseFactory = (type) => {
 			return (
 				<UiBase
 					{...rest}
-					getComponentProps={this.getComponentProps}
 					itemRenderer={({index, ...itemRest}) => ( // eslint-disable-line react/jsx-no-bind
 						itemRenderer({
 							...itemRest,
@@ -816,7 +808,6 @@ const VirtualListBaseFactory = (type) => {
 						return itemsRenderer({
 							...props,
 							handlePlaceholderFocus: this.handlePlaceholderFocus,
-							needsScrollingPlaceholder,
 							role
 						});
 					}}
@@ -922,7 +913,6 @@ const listItemsRenderer = (props) => {
 		cc,
 		handlePlaceholderFocus,
 		itemContainerRef: initUiItemContainerRef,
-		needsScrollingPlaceholder,
 		primary,
 		role
 	} = props;
@@ -942,9 +932,6 @@ const listItemsRenderer = (props) => {
 					onFocus={handlePlaceholderFocus}
 				/>
 			)}
-			{needsScrollingPlaceholder ? (
-				<SpotlightPlaceholder />
-			) : null}
 		</React.Fragment>
 	);
 };

--- a/VirtualList/VirtualListBase.js
+++ b/VirtualList/VirtualListBase.js
@@ -27,9 +27,10 @@ const
 	isUp = is('up'),
 	JS = 'JS',
 	Native = 'Native',
-	// using 'bitwise or' for string > number conversion based on performance: https://jsperf.com/convert-string-to-number-techniques/7
 	getNumberValue = (index) => {
+		// using '+ operator' for string > number conversion based on performance: https://jsperf.com/convert-string-to-number-techniques/7
 		let number = +index;
+		// should return -1 if index is not a number or a negative value
 		return number >= 0 ? number : -1;
 	},
 	nop = () => {},

--- a/VirtualList/VirtualListBase.js
+++ b/VirtualList/VirtualListBase.js
@@ -3,7 +3,7 @@ import {is} from '@enact/core/keymap';
 import Spotlight, {getDirection} from '@enact/spotlight';
 import Accelerator from '@enact/spotlight/Accelerator';
 import Pause from '@enact/spotlight/Pause';
-import {Spottable, spottableClass} from '@enact/spotlight/Spottable';
+import {Spottable} from '@enact/spotlight/Spottable';
 import {VirtualListBase as UiVirtualListBase, VirtualListBaseNative as UiVirtualListBaseNative} from '@enact/ui/VirtualList';
 import PropTypes from 'prop-types';
 import clamp from 'ramda/src/clamp';
@@ -33,8 +33,7 @@ const
 		// should return -1 if index is not a number or a negative value
 		return number >= 0 ? number : -1;
 	},
-	nop = () => {},
-	spottableSelector = `.${spottableClass}`;
+	nop = () => {};
 
 /**
  * The base version of [VirtualListBase]{@link moonstone/VirtualList.VirtualListBase} and
@@ -353,6 +352,10 @@ const VirtualListBaseFactory = (type) => {
 			}, null);
 		}
 
+		/*
+		 * Returns a node for a given index after checking `data-index` attribute.
+		 * Returns null if no matching node is found.
+		 */
 		getItemNode = (index) => {
 			const
 				{numOfItems} = this.uiRefCurrent.state,
@@ -475,9 +478,7 @@ const VirtualListBaseFactory = (type) => {
 					this.isScrolledBy5way = true;
 					this.isWrappedBy5way = isWrapped;
 
-					if (isWrapped && wrap === true && (
-						this.uiRefCurrent.containerRef.current.querySelector(`[data-index='${nextIndex}']${spottableSelector}`) == null
-					)) {
+					if (isWrapped && wrap === true && this.getItemNode(nextIndex)) {
 						this.pause.pause();
 						target.blur();
 					}

--- a/VirtualList/VirtualListBase.js
+++ b/VirtualList/VirtualListBase.js
@@ -478,7 +478,7 @@ const VirtualListBaseFactory = (type) => {
 					this.isScrolledBy5way = true;
 					this.isWrappedBy5way = isWrapped;
 
-					if (isWrapped && wrap === true && this.getItemNode(nextIndex)) {
+					if (isWrapped && wrap === true && this.getItemNode(nextIndex) === null) {
 						this.pause.pause();
 						target.blur();
 					}

--- a/samples/sampler/stories/qa/VirtualList.js
+++ b/samples/sampler/stories/qa/VirtualList.js
@@ -338,13 +338,6 @@ storiesOf('VirtualList', module)
 		() => {
 			return (
 				<VirtualList
-					overscrollEffectOn={{
-						arrowKey: false,
-						drag: false,
-						pageKey: true,
-						track: false,
-						wheel: false
-					}}
 					dataSize={updateDataSize(number('dataSize', Config, defaultDataSize))}
 					focusableScrollbar={boolean('focusableScrollbar', Config)}
 					itemRenderer={renderItem(ContainerItemWithControls, ri.scale(number('itemSize', Config, 78)), true)}

--- a/samples/sampler/stories/qa/VirtualList.js
+++ b/samples/sampler/stories/qa/VirtualList.js
@@ -1,3 +1,4 @@
+import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import {action} from '@enact/storybook-utils/addons/actions';
 import {boolean, number, select} from '@enact/storybook-utils/addons/knobs';
 import {mergeComponentMetadata} from '@enact/storybook-utils';
@@ -7,6 +8,7 @@ import {VirtualListBase as UiVirtualListBase} from '@enact/ui/VirtualList';
 import React, {useState} from 'react';
 import PropTypes from 'prop-types';
 
+import IconButton from '@enact/moonstone/IconButton';
 import Item from '@enact/moonstone/Item';
 import {ActivityPanels, Panel, Header} from '@enact/moonstone/Panels';
 import Scroller from '@enact/moonstone/Scroller';
@@ -116,6 +118,29 @@ class StatefulSwitchItem extends React.Component {
 		);
 	}
 }
+
+const ContainerItemWithControls = SpotlightContainerDecorator(({children, index, style, ...rest}) => {
+	const itemHeight = ri.scaleToRem(78);
+	const containerStyle = {...style, display: 'flex', width: '100%', height: itemHeight};
+	const textStyle = {flex: '1 1 100%', lineHeight: itemHeight};
+	const IconStyle = {flex: '0 0 auto', marginTop: ri.scaleToRem(9)};
+	return (
+		<div {...rest} style={containerStyle}>
+			<div style={textStyle}>
+				{children}
+			</div>
+			<IconButton data-index={index} style={IconStyle}>
+				{'list'}
+			</IconButton>
+			<IconButton data-index={index} style={IconStyle}>
+				{'star'}
+			</IconButton>
+			<IconButton data-index={index} style={IconStyle}>
+				{'home'}
+			</IconButton>
+		</div>
+	);
+});
 
 // eslint-disable-next-line enact/prop-types
 const InPanels = ({className, title, ...rest}) => {
@@ -303,6 +328,28 @@ storiesOf('VirtualList', module)
 					focusableScrollbar={boolean('focusableScrollbar', Config)}
 					itemRenderer={renderItem(StatefulSwitchItem, ri.scale(number('itemSize', Config, 72)), true)}
 					itemSize={ri.scale(number('itemSize', Config, 72))}
+				/>
+			);
+		},
+		{propTables: [Config]}
+	)
+	.add(
+		'with container items have spottable controls',
+		() => {
+			return (
+				<VirtualList
+					overscrollEffectOn={{
+						arrowKey: false,
+						drag: false,
+						pageKey: true,
+						track: false,
+						wheel: false
+					}}
+					dataSize={updateDataSize(number('dataSize', Config, defaultDataSize))}
+					focusableScrollbar={boolean('focusableScrollbar', Config)}
+					itemRenderer={renderItem(ContainerItemWithControls, ri.scale(number('itemSize', Config, 78)), true)}
+					itemSize={ri.scale(number('itemSize', Config, 78))}
+					wrap={wrapOption[select('wrap', ['false', 'true', '"noAnimation"'], Config)]}
 				/>
 			);
 		},

--- a/tests/ui/specs/VirtualList/VirtualList-specs.js
+++ b/tests/ui/specs/VirtualList/VirtualList-specs.js
@@ -1,6 +1,6 @@
 
 const Page = require('./VirtualListPage'),
-	{expectFocusedItem, expectNoFocusedItem, waitForScrollStop, waitUntilFocused} = require('./VirtualList-utils');
+	{expectFocusedItem, expectNoFocusedItem, waitForScrollStop, waitUntilFocused, waitUntilVisible} = require('./VirtualList-utils');
 
 describe('VirtualList', function () {
 
@@ -362,6 +362,7 @@ describe('VirtualList', function () {
 			for (let i = 30; i < 99; ++i) {
 				Page.spotlightDown();
 				waitUntilFocused(i + 1);
+				waitUntilVisible(i + 1);
 			}
 			// Verify Step 8: 1. Spotlight displays on the last item.
 			expectFocusedItem(99, 'focus Item 99');
@@ -375,6 +376,7 @@ describe('VirtualList', function () {
 			for (let i = 0; i < 99; ++i) {
 				Page.spotlightUp();
 				waitUntilFocused(98 - i);
+				waitUntilVisible(98 - i);
 			}
 			// Verify Step 9: 1. Spotlight displays on the first item.
 			expectFocusedItem(0, 'focus Item 0');

--- a/tests/ui/specs/VirtualList/VirtualList-utils.js
+++ b/tests/ui/specs/VirtualList/VirtualList-utils.js
@@ -3,6 +3,17 @@ function focusedElement () {
 	return browser.execute(function () { return document.activeElement.id; });
 }
 
+function hitTest (_selector) {
+	return  browser.execute(function (selector) {
+		const
+			target = document.querySelector(selector),
+			targetRect = target.getBoundingClientRect(),
+			targetDown = [targetRect.x + (targetRect.width / 2), targetRect.y + targetRect.height - 1],
+			targetTop = [targetRect.x + (targetRect.width / 2), targetRect.y + 1];
+		return target.contains(document.elementFromPoint(...targetDown)) || target.contains(document.elementFromPoint(...targetTop));
+	}, _selector);
+}
+
 function expectFocusedItem (itemNum, comment = 'focused item') {
 	const focusedId = focusedElement();
 	expect(focusedId, comment).to.equal(`item${itemNum}`);
@@ -18,6 +29,12 @@ function waitUntilFocused (itemNum) {
 		const focusedId = focusedElement();
 		return target === focusedId;
 	}, 1500, `timed out waiting to focus index ${itemNum}`);
+}
+
+function waitUntilVisible (itemNum) {
+	browser.waitUntil(function () {
+		return hitTest(`#item${itemNum}`);
+	}, 1500, `timed out waiting until visible index ${itemNum}`);
 }
 
 function isScrolling () {
@@ -52,3 +69,4 @@ exports.expectNoFocusedItem = expectNoFocusedItem;
 exports.waitForScrollStartStop = waitForScrollStartStop;
 exports.waitForScrollStop = waitForScrollStop;
 exports.waitUntilFocused = waitUntilFocused;
+exports.waitUntilVisible = waitUntilVisible;

--- a/tests/ui/specs/VirtualList/VirtualListPage.js
+++ b/tests/ui/specs/VirtualList/VirtualListPage.js
@@ -1,6 +1,5 @@
 'use strict';
-const {Page} = require('@enact/ui-test-utils/utils');
-const {element} = require('@enact/ui-test-utils/utils');
+const {element, Page} = require('@enact/ui-test-utils/utils');
 
 const scrollableSelector = '.enact_ui_Scrollable_Scrollable_scrollable';
 const scrollbarSelector = '.Scrollable_Scrollbar_scrollbar';


### PR DESCRIPTION
Supports spottable children inside a spotlight container item.
- Basically, use spotlight logic for navigation between spottable children across items.
- Removed `initItemRef` as it does not work any longer after PLAT-76082
- Removed unused `SpotlightPlaceholder` which was added for disabled items case in ENYO-4220 since disabled items are also spottable now.

Checklist (affected scenarios)
- Scrolling on a virtual grid list with spottable inner controls with wrap options (both with/without animation)
- Restoring focus on panel navigation

Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)