### PR TITLE
PLAT-111070: Fix ".inline is not a function" error on LabeledIcon

### DIFF
--- a/LabeledIcon/LabeledIcon.js
+++ b/LabeledIcon/LabeledIcon.js
@@ -16,7 +16,7 @@
  */
 
 import kind from '@enact/core/kind';
-import UiLabeledIcon from '@enact/ui/LabeledIcon';
+import {LabeledIconBase as UiLabeledIconBase, LabeledIconDecorator as UiLabeledIconDecorator} from '@enact/ui/LabeledIcon';
 import Pure from '@enact/ui/internal/Pure';
 import PropTypes from 'prop-types';
 import compose from 'ramda/src/compose';
@@ -34,6 +34,7 @@ const Icon = Skinnable(IconBase);
  *
  * @class LabeledIconBase
  * @memberof moonstone/LabeledIcon
+ * @extends ui/LabeledIcon.LabeledIconBase
  * @ui
  * @public
  */
@@ -64,7 +65,7 @@ const LabeledIconBase = kind({
 	},
 
 	render: (props) => {
-		return UiLabeledIcon.inline({
+		return UiLabeledIconBase.inline({
 			...props,
 			iconComponent: Icon,
 			css: props.css
@@ -77,10 +78,12 @@ const LabeledIconBase = kind({
  *
  * @hoc
  * @memberof moonstone/LabeledIcon
+ * @mixes moonstone/LabeledIcon.LabeledIconDecorator
  * @mixes moonstone/Skinnable.Skinnable
  * @public
  */
 const LabeledIconDecorator = compose(
+	UiLabeledIconDecorator,
 	Pure,
 	Skinnable
 );

--- a/LabeledIcon/LabeledIcon.js
+++ b/LabeledIcon/LabeledIcon.js
@@ -78,7 +78,7 @@ const LabeledIconBase = kind({
  *
  * @hoc
  * @memberof moonstone/LabeledIcon
- * @mixes moonstone/LabeledIcon.LabeledIconDecorator
+ * @mixes ui/LabeledIcon.LabeledIconDecorator
  * @mixes moonstone/Skinnable.Skinnable
  * @public
  */

--- a/LabeledIconButton/LabeledIconButton.js
+++ b/LabeledIconButton/LabeledIconButton.js
@@ -159,7 +159,7 @@ const LabeledIconButtonBase = kind({
  *
  * @hoc
  * @memberof moonstone/LabeledIconButton
- * @mixes moonstone/LabeledIcon.LabeledIconDecorator
+ * @mixes ui/LabeledIcon.LabeledIconDecorator
  * @mixes moonstone/Skinnable.Skinnable
  * @public
  */

--- a/LabeledIconButton/LabeledIconButton.js
+++ b/LabeledIconButton/LabeledIconButton.js
@@ -19,7 +19,7 @@
 import kind from '@enact/core/kind';
 import Spottable from '@enact/spotlight/Spottable';
 import {IconButtonDecorator as UiIconButtonDecorator} from '@enact/ui/IconButton';
-import UiLabeledIcon from '@enact/ui/LabeledIcon';
+import {LabeledIconBase as UiLabeledIconBase, LabeledIconDecorator as UiLabeledIconDecorator} from '@enact/ui/LabeledIcon';
 import Pure from '@enact/ui/internal/Pure';
 import PropTypes from 'prop-types';
 import compose from 'ramda/src/compose';
@@ -41,7 +41,7 @@ const IconButton = compose(
  *
  * @class LabeledIconButtonBase
  * @memberof moonstone/LabeledIconButton
- * @extends ui/LabeledIcon.LabeledIcon
+ * @extends ui/LabeledIcon.LabeledIconBase
  * @ui
  * @public
  */
@@ -135,7 +135,7 @@ const LabeledIconButtonBase = kind({
 	},
 
 	render: ({css, flip, icon, selected, 'data-webos-voice-disabled': voiceDisabled, 'data-webos-voice-group-label': voiceGroupLabel, 'data-webos-voice-intent': voiceIntent, 'data-webos-voice-label': voiceLabel, ...rest}) => {
-		return UiLabeledIcon.inline({
+		return UiLabeledIconBase.inline({
 			...rest,
 			icon: (
 				<IconButton
@@ -159,10 +159,12 @@ const LabeledIconButtonBase = kind({
  *
  * @hoc
  * @memberof moonstone/LabeledIconButton
+ * @mixes moonstone/LabeledIcon.LabeledIconDecorator
  * @mixes moonstone/Skinnable.Skinnable
  * @public
  */
 const LabeledIconButtonDecorator = compose(
+	UiLabeledIconDecorator,
 	Pure,
 	Skinnable
 );


### PR DESCRIPTION
Fixed ".inline is not a function" error on LabeledIcon and LabeledIconButton.
This error is due to ui/Slottable migration from `kind` to `function`
Changed import from `ui/LabeledIcon` to `ui/LabeldIconBase`

Enact-DCO-1.0-Signed-off-by: Seungho Park <seunghoh.park@lge.com>