### PR TITLE
PLAT-113850: Fixed broken logic covering edge cases of an invalid `data-index` value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
+- `moonstone/VirtualList` to handle keydown properly when an item has a wrong index value
 - `moonstone/VirtualList` to support navigation with spottable children inside an item
 - `moonstone/VirtualList.VirtualList`, `moonstone/VirtualList.VirtualGridList` add `data-webos-voice-disabled` prop for disable voice control
 - `moonstone/LabeledIconButton` add props to change voice control in IconButton

--- a/VirtualList/VirtualListBase.js
+++ b/VirtualList/VirtualListBase.js
@@ -456,7 +456,7 @@ const VirtualListBaseFactory = (type) => {
 			this.isScrolledBy5way = false;
 			this.isScrolledByJump = false;
 
-			if (nextIndex >= 0) {
+			if (nextIndex >= 0 && index >= 0) {
 				const
 					row = Math.floor(index / dimensionToExtent),
 					nextRow = Math.floor(nextIndex / dimensionToExtent),
@@ -522,7 +522,7 @@ const VirtualListBaseFactory = (type) => {
 						if (!ev.currentTarget.contains(candidate)) { // if the candidate is out of a list
 							isLeaving = true;
 						}
-					} else if (candidateIndex !== index) { // the focused node is an item and focus will move out of the item
+					} else if (index >= 0 && candidateIndex !== index) { // the focused node is an item and focus will move out of the item
 						const {repeat} = ev;
 						const {isDownKey, isUpKey, isLeftMovement, isRightMovement, isWrapped, nextIndex} = this.getNextIndex({index, keyCode, repeat});
 


### PR DESCRIPTION
`getNumberValue` returns _-1_ for invalid `data-index` attribute of an item DOM node. So we can check the validity of a converted value to decide whether we take our focus and scroll logic or leave a behavior up to Spotlight.

Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)