### PR TITLE
PLAT-122566: Fix ui-test fail on DatePicker, TimePicker, and Popup

### DIFF
--- a/tests/ui/specs/DatePicker/DatePicker-specs.js
+++ b/tests/ui/specs/DatePicker/DatePicker-specs.js
@@ -5,6 +5,7 @@ const {daysInMonth, expectClosed, expectNoLabels, expectOpen, extractValues, val
 describe('DatePicker', function () {
 
 	it('should have focus on start', function () {
+		Page.open();
 		expect(Page.components.datePickerDefaultClosedWithoutNoneText.title.isFocused()).to.be.true();
 	});
 

--- a/tests/ui/specs/DatePicker/DatePicker-specs.js
+++ b/tests/ui/specs/DatePicker/DatePicker-specs.js
@@ -3,7 +3,6 @@ const Page = require('./DatePickerPage');
 const {daysInMonth, expectClosed, expectNoLabels, expectOpen, extractValues, validateTitle} = require('./DatePicker-utils.js');
 
 describe('DatePicker', function () {
-	Page.open();
 
 	it('should have focus on start', function () {
 		expect(Page.components.datePickerDefaultClosedWithoutNoneText.title.isFocused()).to.be.true();

--- a/tests/ui/specs/Popup/Popup-specs.js
+++ b/tests/ui/specs/Popup/Popup-specs.js
@@ -814,7 +814,7 @@ describe('Popup', function () {
 				expectOpen(popupCommon);
 				Page.showPointerByKeycode();
 				// Position the pointer inside popup to the right of the Cancel button (step 4)
-				$('#buttonCancel').moveTo(200, 200);
+				$('#popup6').moveTo(500, 150);
 				// 5-way to the Cancel button
 				Page.spotlightLeft();
 				// Spotight is on Cancel button (verify step 4)
@@ -844,7 +844,7 @@ describe('Popup', function () {
 				// Wave the pointer to change to cursor mode (step 5)
 				Page.showPointerByKeycode();
 				// Position the pointer on the right of the Cancel buttion inside popup
-				$('#buttonCancel').moveTo(200, 200);
+				$('#popup6').moveTo(500, 150);
 				// Spotlight on button in popup is blur (verify step 5)
 				expect(popup.buttonOK.isFocused()).to.be.false();
 				// Change from pointer to 5-way mode (step 6)

--- a/tests/ui/specs/TimePicker/TimePicker-specs.js
+++ b/tests/ui/specs/TimePicker/TimePicker-specs.js
@@ -5,6 +5,7 @@ const {expectClosed, expectOpen, expectNoLabels, extractValues, validateTitle} =
 describe('TimePicker', function () {
 
 	it('should have focus on start', function () {
+		Page.open();
 		expect(Page.components.timePickerDefaultClosedWithoutNoneText.title.isFocused()).to.be.true();
 	});
 

--- a/tests/ui/specs/TimePicker/TimePicker-specs.js
+++ b/tests/ui/specs/TimePicker/TimePicker-specs.js
@@ -3,7 +3,6 @@ const Page = require('./TimePickerPage');
 const {expectClosed, expectOpen, expectNoLabels, extractValues, validateTitle} = require('./TimePicker-utils.js');
 
 describe('TimePicker', function () {
-	Page.open();
 
 	it('should have focus on start', function () {
 		expect(Page.components.timePickerDefaultClosedWithoutNoneText.title.isFocused()).to.be.true();


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn <jeonghee27.ahn@lge.com>

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

There is ui-test fail on `DatePicker`, `TimePicker`, and  `Popup` (Jenkins: enact-ui-tests/707)
```
Error:  Unable to load spec files quite likely because they rely on `browser` object that is not fully initialised.
```

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Remove wrong page open on DatePicker and TimePicker.
- Fix Popup test script - Re-position the mouse point to suit the original TC intention.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
PLAT-122566
Moonstone result on Jenkins: enact-ui-tests/710/

### Comments