### PR TITLE
PLAT-123245: Fixed ExpandableList focus moves to unexpected position on closing when selecting an item via touch input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/ExpandableList` to keep focus position properly when selecting item by touch
+- `moonstone/ExpandableList` to keep focus properly when selecting an item by touch
 - `moonstone/Panels` Breadcrumb to get focus when touching
 
 ## [3.3.0] - 2020-10-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
+- `moonstone/ExpandableList` to keep focus position properly when selecting item by touch
 - `moonstone/Panels` Breadcrumb to get focus when touching
 
 ## [3.3.0] - 2020-10-08

--- a/DaySelector/tests/DaySelector-specs.js
+++ b/DaySelector/tests/DaySelector-specs.js
@@ -6,6 +6,7 @@ import DaySelector from '../DaySelector';
 const tap = (node) => {
 	node.simulate('mousedown');
 	node.simulate('mouseup');
+	node.simulate('click');
 };
 
 describe('DaySelector', () => {

--- a/ExpandableItem/ExpandableItem.js
+++ b/ExpandableItem/ExpandableItem.js
@@ -402,7 +402,7 @@ const ExpandableItemBase = kind({
 					data-expandable-label
 					disabled={disabled}
 					label={label}
-					onTap={handleOpen}
+					onClick={handleOpen}
 					onKeyDown={handleLabelKeyDown}
 					onSpotlightDisappear={onSpotlightDisappear}
 					onSpotlightLeft={onSpotlightLeft}

--- a/ToggleItem/ToggleItem.js
+++ b/ToggleItem/ToggleItem.js
@@ -22,10 +22,13 @@
 import hoc from '@enact/core/hoc';
 import kind from '@enact/core/kind';
 import EnactPropTypes from '@enact/core/internal/prop-types';
+import ForwardRef from '@enact/ui/ForwardRef';
 import Pure from '@enact/ui/internal/Pure';
 import React from 'react';
 import PropTypes from 'prop-types';
-import {ToggleItemBase as UiToggleItem, ToggleItemDecorator as UiToggleItemDecorator} from '@enact/ui/ToggleItem';
+import Toggleable from '@enact/ui/Toggleable';
+import {ToggleItemBase as UiToggleItem} from '@enact/ui/ToggleItem';
+import Touchable from '@enact/ui/Touchable';
 import Spottable from '@enact/spotlight/Spottable';
 import compose from 'ramda/src/compose';
 
@@ -143,7 +146,9 @@ const defaultConfig = {
 const ToggleItemDecorator = hoc(defaultConfig, ({invalidateProps}, Wrapped) => {
 	return compose(
 		Pure,
-		UiToggleItemDecorator,
+		ForwardRef({prop: 'componentRef'}),
+		Toggleable({toggleProp: 'onClick', eventProps: ['value']}),
+		Touchable,
 		Spottable,
 		MarqueeDecorator({className: componentCss.content, invalidateProps}),
 		Skinnable

--- a/samples/sampler/stories/qa/ExpandableList.js
+++ b/samples/sampler/stories/qa/ExpandableList.js
@@ -107,13 +107,22 @@ storiesOf('ExpandableList', module)
 		'grouped',
 		() => (
 			<ExpandableGroup>
-				<ExpandableList title="First">
+				<ExpandableList
+					closeOnSelect={boolean('closeOnSelect', Config)}
+					title="First"
+				>
 					{['One', 'Two', 'Three']}
 				</ExpandableList>
-				<ExpandableList title="Second">
+				<ExpandableList
+					closeOnSelect={boolean('closeOnSelect', Config)}
+					title="Second"
+				>
 					{['Fourth', 'Fifth', 'Sixth']}
 				</ExpandableList>
-				<ExpandableList title="Third">
+				<ExpandableList
+					closeOnSelect={boolean('closeOnSelect', Config)}
+					title="Third"
+				>
 					{['Seventh', 'Eighth', 'Ninth']}
 				</ExpandableList>
 			</ExpandableGroup>


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

The focus moves to an unexpected position on closing ExpandableList when selecting an item via touch input

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Since 'focus' event occurs after 'onTap' callback, focusing occurs during ExpandableList is closing.
To resolve this case, I made ExpandableList to be closed when 'onClick' occurs.

### Links
[//]: # (Related issues, references)
PLAT-123245

Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)