### PR TITLE
PLAT-135307: Updates to add global handlers to React DOM tree root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Added
+
+- `agate/ThemeDecorator` config `rootId` to specify React DOM tree root for global event handlers
+
 ## [3.3.1] - 2020-11-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Added
 
-- `agate/ThemeDecorator` config `rootId` to specify React DOM tree root for global event handlers
+- `moonstone/MoonstoneDecorator` config `rootId` to specify React DOM tree root for global event handlers
 
 ## [3.3.1] - 2020-11-02
 

--- a/MoonstoneDecorator/MoonstoneDecorator.js
+++ b/MoonstoneDecorator/MoonstoneDecorator.js
@@ -5,6 +5,7 @@
  * @exports MoonstoneDecorator
  */
 
+import {setDefaultTargetById} from '@enact/core/dispatcher';
 import {addAll} from '@enact/core/keymap';
 import hoc from '@enact/core/hoc';
 import I18nDecorator from '@enact/i18n/I18nDecorator';
@@ -107,6 +108,15 @@ const defaultConfig = /** @lends moonstone/MoonstoneDecorator.MoonstoneDecorator
 	},
 
 	/**
+	 * Specifies the id of the React DOM tree root node
+	 *
+	 * @type {String}
+	 * @default 'root'
+	 * @public
+	 */
+	rootId: 'root',
+
+	/**
 	 * Applies skinning support.
 	 *
 	 * @type {Boolean}
@@ -157,7 +167,7 @@ const defaultConfig = /** @lends moonstone/MoonstoneDecorator.MoonstoneDecorator
  */
 const MoonstoneDecorator = hoc(defaultConfig, (config, Wrapped) => {
 	const {accessible, ri, i18n, spotlight, float, noAutoFocus, overlay,
-		skin, disableFullscreen} = config;
+		skin, disableFullscreen, rootId} = config;
 
 	// Apply classes depending on screen type (overlay / fullscreen)
 	const bgClassName = classNames({
@@ -215,6 +225,9 @@ const MoonstoneDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		pointerHide: 1537,
 		pointerShow: 1536
 	});
+
+	// set the DOM node ID of the React DOM tree root
+	setDefaultTargetById(rootId);
 
 	// configure the default hold time
 	configure({


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The UI tests for Popup with scrimType="none" were failing. The popup was closing right after it was opening. The is due to React's changes of event delegation from version 17, event callback order is changed in some components which add event handlers to `document`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
A new config prop is added to `ThemeDecorator` to setup the React DOM tree. The default value is `root` as Enact CLI renders an app into the node has `id='root'`.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Unit tests fail on Travis, but they pass locally

### Links
[//]: # (Related issues, references)
PLAT-135307

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian (daniel.stoian@lge.com)