### PR TITLE
PLAT-73431: Rename `onHold` and `onHoldPulse` to `onHoldStart` and `onHold` respectively

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,15 @@ install:
     - npm config set prefer-offline true
     - npm install -g enactjs/cli#develop
     - npm install -g codecov
+    - git clone --branch=develop --depth 1 https://github.com/enactjs/enact ../enact
+    - pushd ../enact
     - npm install
+    - npm run lerna exec -- --ignore enact-sampler --concurrency 1 -- npm --no-package-lock link
+    - npm run lerna link -- --ignore enact-sampler
+    - popd
+    - rm -fr node_modules/@enact
+    - npm install
+    - enact link
 script:
     - echo -e "\x1b\x5b35;1m*** Starting tests...\x1b\x5b0m"
     - npm test -- --runInBand --coverage

--- a/IncrementSlider/IncrementSliderButton.js
+++ b/IncrementSlider/IncrementSliderButton.js
@@ -29,7 +29,7 @@ const IncrementSliderButtonBase = kind({
 				backgroundOpacity="transparent"
 				onTap={onTap}
 				onHold={onTap}
-				onHoldPulse={onTap}
+				onHoldStart={onTap}
 				size="small"
 			/>
 		);

--- a/Scrollable/ScrollButtons.js
+++ b/Scrollable/ScrollButtons.js
@@ -368,7 +368,7 @@ class ScrollButtons extends Component {
 				key="prevButton"
 				onClick={this.onClickPrev}
 				onDown={this.onDownPrev}
-				onHoldPulse={this.onClickPrev}
+				onHold={this.onClickPrev}
 				ref={this.prevButtonRef}
 			>
 				{prevIcon}
@@ -381,7 +381,7 @@ class ScrollButtons extends Component {
 				key="nextButton"
 				onClick={this.onClickNext}
 				onDown={this.onDownNext}
-				onHoldPulse={this.onClickNext}
+				onHold={this.onClickNext}
 				ref={this.nextButtonRef}
 			>
 				{nextIcon}

--- a/internal/Picker/Picker.js
+++ b/internal/Picker/Picker.js
@@ -579,7 +579,7 @@ const PickerBase = class extends React.Component {
 		this.pickerButtonPressed = 1;
 	};
 
-	handleHoldPulse = () => {
+	handleHold = () => {
 		const {joined} = this.props;
 		if (joined && this.pickerButtonPressed === 1) {
 			this.handleIncrement();
@@ -878,7 +878,7 @@ const PickerBase = class extends React.Component {
 				onBlur={this.handleBlur}
 				onDown={this.handleDown}
 				onFocus={this.handleFocus}
-				onHoldPulse={this.handleHoldPulse}
+				onHold={this.handleHold}
 				onKeyDown={this.handleKeyDown}
 				onKeyUp={this.handleKeyUp}
 				onUp={this.handleUp}
@@ -898,7 +898,7 @@ const PickerBase = class extends React.Component {
 					icon={incrementIcon}
 					joined={joined}
 					onDown={this.handleIncrement}
-					onHoldPulse={this.handleIncrement}
+					onHold={this.handleIncrement}
 					onKeyDown={this.handleIncKeyDown}
 					onSpotlightDisappear={onSpotlightDisappear}
 					spotlightDisabled={spotlightDisabled}
@@ -935,7 +935,7 @@ const PickerBase = class extends React.Component {
 					icon={decrementIcon}
 					joined={joined}
 					onDown={this.handleDecrement}
-					onHoldPulse={this.handleDecrement}
+					onHold={this.handleDecrement}
 					onKeyDown={this.handleDecKeyDown}
 					onSpotlightDisappear={onSpotlightDisappear}
 					spotlightDisabled={spotlightDisabled}

--- a/samples/sampler/stories/qa/Touchable.js
+++ b/samples/sampler/stories/qa/Touchable.js
@@ -75,7 +75,7 @@ storiesOf('Touchable', module)
 			<Button
 				onHold={action('onHold')}
 				onHoldEnd={action('onHoldEnd')}
-				onHoldPulse={action('onHoldPulse')}
+				onHoldStart={action('onHoldStart')}
 				disabled={boolean('disabled', Button)}
 			>
 				Touchable
@@ -95,7 +95,7 @@ storiesOf('Touchable', module)
 				}}
 				onHold={action('onHold')}
 				onHoldEnd={action('onHoldEnd')}
-				onHoldPulse={action('onHoldPulse')}
+				onHoldStart={action('onHoldStart')}
 				disabled={boolean('disabled', Button)}
 			>
 				LongPress
@@ -115,8 +115,9 @@ storiesOf('Touchable', module)
 					}}
 					moveTolerance={moveTolerance}
 					noResume={boolean('noResume', TouchArea, false)}
-					onHold={action('onHold')}
-					onHoldPulse={action('onHoldPulse', {depth: 0})}
+					onHold={action('onHold', {depth: 0})}
+					onHoldEnd={action('onHoldEnd')}
+					onHoldStart={action('onHoldStart')}
 					disabled={boolean('disabled', TouchArea)}
 					style={{marginLeft: 'auto', marginRight: 'auto', textAlign: 'center', border: '2px dashed #888', width: ri.unit(ri.scale(240), 'rem'), height: ri.unit(ri.scale(240), 'rem')}}
 				>
@@ -132,7 +133,7 @@ storiesOf('Touchable', module)
 				noResume={boolean('noResume', Button, true)}
 				onHold={action('onHold')}
 				onHoldEnd={action('onHoldEnd')}
-				onHoldPulse={action('onHoldPulse')}
+				onHoldStart={action('onHoldStart')}
 				disabled={boolean('disabled', Button)}
 			>
 				Not Resumable


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Currently, `Touchable` dispatches `onHold`, `onHoldPulse`, and `onHoldEnd` events for holding down events and events' names are not matched with other regular events like `TouchStart` and `TouchEnd`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
To make the hold events to get the semantics the same, we'd like to rename `onHold` to `onHoldStart` and `onHoldPulse` to `onHold`.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Since `onHold` will have a different meaning after this change, we need to ship this change in the major version update to minimize issues from backward compatibility.

### Links
[//]: # (Related issues, references)
PLAT-73431
https://github.com/enactjs/enact/pull/2901

### Comments
