### PR TITLE
PLAT-139207: Fixed EditableIntegerPicker console error - Function components cannot be given refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/EditableIntegerPicker` to use `@enact/ui/ForwardRef` for `pickerRef` prop
+- `moonstone/EditableIntegerPicker` to use to correctly pass reference to `moonstone/internal/Picker`
 
 ## [4.0.0-alpha.1] - 2021-02-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/EditableIntegerPicker` to use `@enact/ui/ForwardRef` for `pickerRef` prop
+
 ## [4.0.0-alpha.1] - 2021-02-25
 
 -  The framework was updated to support React 17.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
-## [unreleased]
-
-### Fixed
-
-- `moonstone/EditableIntegerPicker` to use to correctly pass reference to `moonstone/internal/Picker`
-
 ## [4.0.0] - 2021-04-08
 
 - The framework was updated to be compatible with Enact 4.0.0

--- a/EditableIntegerPicker/EditableIntegerPicker.js
+++ b/EditableIntegerPicker/EditableIntegerPicker.js
@@ -16,7 +16,6 @@
 import kind from '@enact/core/kind';
 import {clamp} from '@enact/core/util';
 import Changeable from '@enact/ui/Changeable';
-import ForwardRef from "@enact/ui/ForwardRef";
 import Pure from '@enact/ui/internal/Pure';
 import PropTypes from 'prop-types';
 
@@ -315,7 +314,7 @@ const EditableIntegerPickerBase = kind({
 		delete rest.unit;
 
 		return (
-			<Picker aria-valuetext={ariaValueText} {...rest} index={0} ref={pickerRef} />
+			<Picker aria-valuetext={ariaValueText} {...rest} index={0} componentRef={pickerRef} />
 		);
 	}
 });
@@ -340,7 +339,7 @@ const EditableIntegerPicker = Pure(
 		EditableIntegerPickerDecorator(
 			MarqueeController(
 				{marqueeOnFocus: true},
-				ForwardRef({prop: 'pickerRef'}, EditableIntegerPickerBase)
+				EditableIntegerPickerBase
 			)
 		)
 	)

--- a/EditableIntegerPicker/EditableIntegerPicker.js
+++ b/EditableIntegerPicker/EditableIntegerPicker.js
@@ -340,7 +340,7 @@ const EditableIntegerPicker = Pure(
 		EditableIntegerPickerDecorator(
 			MarqueeController(
 				{marqueeOnFocus: true},
-				ForwardRef({prop: 'pickerRef'}, EditableIntegerPickerBase),
+				ForwardRef({prop: 'pickerRef'}, EditableIntegerPickerBase)
 			)
 		)
 	)

--- a/EditableIntegerPicker/EditableIntegerPicker.js
+++ b/EditableIntegerPicker/EditableIntegerPicker.js
@@ -16,6 +16,7 @@
 import kind from '@enact/core/kind';
 import {clamp} from '@enact/core/util';
 import Changeable from '@enact/ui/Changeable';
+import ForwardRef from "@enact/ui/ForwardRef";
 import Pure from '@enact/ui/internal/Pure';
 import PropTypes from 'prop-types';
 
@@ -339,7 +340,7 @@ const EditableIntegerPicker = Pure(
 		EditableIntegerPickerDecorator(
 			MarqueeController(
 				{marqueeOnFocus: true},
-				EditableIntegerPickerBase
+				ForwardRef({prop: 'pickerRef'}, EditableIntegerPickerBase),
 			)
 		)
 	)

--- a/internal/Picker/Picker.js
+++ b/internal/Picker/Picker.js
@@ -1,6 +1,7 @@
 import {forward, stopImmediate} from '@enact/core/handle';
 import {is} from '@enact/core/keymap';
 import platform from '@enact/core/platform';
+import EnactPropTypes from '@enact/core/internal/prop-types';
 import {cap, clamp, Job} from '@enact/core/util';
 import IdProvider from '@enact/ui/internal/IdProvider';
 import Touchable from '@enact/ui/Touchable';
@@ -163,6 +164,14 @@ const PickerBase = class extends ReactComponent {
 		 * @public
 		 */
 		className: PropTypes.string,
+
+		/**
+		 * Called with a reference to the root component.
+		 *
+		 * @type {Object|Function}
+		 * @public
+		 */
+		componentRef: EnactPropTypes.ref,
 
 		/**
 		 * Disables voice control.

--- a/internal/Picker/Picker.js
+++ b/internal/Picker/Picker.js
@@ -790,7 +790,9 @@ const PickerBase = class extends ReactComponent {
 			// wheel handler to avoid this requirement
 			// eslint-disable-next-line react/no-find-dom-node
 			this[prop] = ref && ReactDOM.findDOMNode(ref);
-			forward('componentRef', ref, this.props);
+			if (this.props.componentRef) {
+				this.props.componentRef(ref);
+			}
 		};
 	}
 

--- a/internal/Picker/Picker.js
+++ b/internal/Picker/Picker.js
@@ -776,11 +776,11 @@ const PickerBase = class extends ReactComponent {
 	}
 
 	initRef (prop) {
-		return (ref) => {
+		return (componentRef) => {
 			// need a way, for now, to get a DOM node ref ~and~ use onUp. Likely should rework the
 			// wheel handler to avoid this requirement
 			// eslint-disable-next-line react/no-find-dom-node
-			this[prop] = ref && ReactDOM.findDOMNode(ref);
+			this[prop] = componentRef && ReactDOM.findDOMNode(componentRef);
 		};
 	}
 
@@ -819,6 +819,7 @@ const PickerBase = class extends ReactComponent {
 
 		delete rest['aria-label'];
 		delete rest.accessibilityHint;
+		delete rest.componentRef;
 		delete rest.decrementAriaLabel;
 		delete rest.decrementIcon;
 		delete rest.incrementAriaLabel;

--- a/internal/Picker/Picker.js
+++ b/internal/Picker/Picker.js
@@ -1,7 +1,7 @@
 import {forward, stopImmediate} from '@enact/core/handle';
+import EnactPropTypes from '@enact/core/internal/prop-types';
 import {is} from '@enact/core/keymap';
 import platform from '@enact/core/platform';
-import EnactPropTypes from '@enact/core/internal/prop-types';
 import {cap, clamp, Job} from '@enact/core/util';
 import IdProvider from '@enact/ui/internal/IdProvider';
 import Touchable from '@enact/ui/Touchable';

--- a/internal/Picker/Picker.js
+++ b/internal/Picker/Picker.js
@@ -776,11 +776,12 @@ const PickerBase = class extends ReactComponent {
 	}
 
 	initRef (prop) {
-		return (componentRef) => {
+		return (ref) => {
 			// need a way, for now, to get a DOM node ref ~and~ use onUp. Likely should rework the
 			// wheel handler to avoid this requirement
 			// eslint-disable-next-line react/no-find-dom-node
-			this[prop] = componentRef && ReactDOM.findDOMNode(componentRef);
+			this[prop] = ref && ReactDOM.findDOMNode(ref);
+			forward('componentRef', ref, this.props);
 		};
 	}
 

--- a/samples/sampler/stories/default/EditableIntegerPicker.js
+++ b/samples/sampler/stories/default/EditableIntegerPicker.js
@@ -6,6 +6,7 @@ import {storiesOf} from '@storybook/react';
 import EditableIntegerPicker, {EditableIntegerPickerBase} from '@enact/moonstone/EditableIntegerPicker';
 
 import {decrementIcons, incrementIcons} from './icons';
+import Button from '../../../../Button';
 
 const Config = mergeComponentMetadata('EditableIntegerPicker', EditableIntegerPickerBase, EditableIntegerPicker);
 EditableIntegerPicker.displayName = 'EditableIntegerPicker';
@@ -20,23 +21,28 @@ storiesOf('Moonstone', module)
 	.add(
 		'EditableIntegerPicker',
 		() => (
-			<EditableIntegerPicker
-				decrementIcon={select('decrementIcon', ['', ...decrementIcons], Config)}
-				defaultValue={20}
-				disabled={boolean('disabled', Config)}
-				incrementIcon={select('incrementIcon', ['', ...incrementIcons], Config)}
-				max={number('max', Config, 100)}
-				min={number('min', Config, 0)}
-				noAnimation={boolean('noAnimation', Config)}
-				onBlur={action('onBlur')}
-				onChange={action('onChange')}
-				onKeyDown={action('onKeyDown')}
-				orientation={select('orientation', prop.orientation, Config)}
-				step={number('step', Config)}
-				unit={text('unit', Config)}
-				width={select('width', prop.width,  Config)}
-				wrap={boolean('wrap', Config)}
-			/>
+			<div>
+				<Button>Hello</Button>
+				<EditableIntegerPicker
+					decrementIcon={select('decrementIcon', ['', ...decrementIcons], Config)}
+					defaultValue={20}
+					disabled={boolean('disabled', Config)}
+					incrementIcon={select('incrementIcon', ['', ...incrementIcons], Config)}
+					max={number('max', Config, 100)}
+					min={number('min', Config, 0)}
+					noAnimation={boolean('noAnimation', Config)}
+					onBlur={action('onBlur')}
+					onChange={action('onChange')}
+					onKeyDown={action('onKeyDown')}
+					orientation={select('orientation', prop.orientation, Config)}
+					step={number('step', Config)}
+					unit={text('unit', Config)}
+					width={select('width', prop.width,  Config)}
+					wrap={boolean('wrap', Config)}
+				/>
+				<Button>Hello</Button>
+			</div>
+
 		),
 		{
 			info: {

--- a/samples/sampler/stories/default/EditableIntegerPicker.js
+++ b/samples/sampler/stories/default/EditableIntegerPicker.js
@@ -6,7 +6,6 @@ import {storiesOf} from '@storybook/react';
 import EditableIntegerPicker, {EditableIntegerPickerBase} from '@enact/moonstone/EditableIntegerPicker';
 
 import {decrementIcons, incrementIcons} from './icons';
-import Button from '../../../../Button';
 
 const Config = mergeComponentMetadata('EditableIntegerPicker', EditableIntegerPickerBase, EditableIntegerPicker);
 EditableIntegerPicker.displayName = 'EditableIntegerPicker';
@@ -21,28 +20,23 @@ storiesOf('Moonstone', module)
 	.add(
 		'EditableIntegerPicker',
 		() => (
-			<div>
-				<Button>Hello</Button>
-				<EditableIntegerPicker
-					decrementIcon={select('decrementIcon', ['', ...decrementIcons], Config)}
-					defaultValue={20}
-					disabled={boolean('disabled', Config)}
-					incrementIcon={select('incrementIcon', ['', ...incrementIcons], Config)}
-					max={number('max', Config, 100)}
-					min={number('min', Config, 0)}
-					noAnimation={boolean('noAnimation', Config)}
-					onBlur={action('onBlur')}
-					onChange={action('onChange')}
-					onKeyDown={action('onKeyDown')}
-					orientation={select('orientation', prop.orientation, Config)}
-					step={number('step', Config)}
-					unit={text('unit', Config)}
-					width={select('width', prop.width,  Config)}
-					wrap={boolean('wrap', Config)}
-				/>
-				<Button>Hello</Button>
-			</div>
-
+			<EditableIntegerPicker
+				decrementIcon={select('decrementIcon', ['', ...decrementIcons], Config)}
+				defaultValue={20}
+				disabled={boolean('disabled', Config)}
+				incrementIcon={select('incrementIcon', ['', ...incrementIcons], Config)}
+				max={number('max', Config, 100)}
+				min={number('min', Config, 0)}
+				noAnimation={boolean('noAnimation', Config)}
+				onBlur={action('onBlur')}
+				onChange={action('onChange')}
+				onKeyDown={action('onKeyDown')}
+				orientation={select('orientation', prop.orientation, Config)}
+				step={number('step', Config)}
+				unit={text('unit', Config)}
+				width={select('width', prop.width,  Config)}
+				wrap={boolean('wrap', Config)}
+			/>
 		),
 		{
 			info: {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When opening sampler for EditableIntegerPicker, a console error was thrown:
`Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?`

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Pass the right ref to the EditableIntegerPicker.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
PLAT-139207

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian daniel.stoian@lgepartner.com