### PR TITLE
PLAT-139208:  Panels: Fix console error - React does not recognize the `controlsRef` and `controlsMeasurements`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/Viewport` to delete `controlsRef` and `controlsMeasurements` from DOM
+
+
 ## [4.0.0-alpha.1] - 2021-02-25
 
 -  The framework was updated to support React 17.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/Viewport` to delete `controlsRef` and `controlsMeasurements` from DOM
 
-
 ## [4.0.0-alpha.1] - 2021-02-25
 
 -  The framework was updated to support React 17.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
-## [unreleased]
+## [4.0.0] - 2021-04-08
+
+-  The framework was updated to be compatible with Enact 4.0.0
 
 ## [4.0.0-alpha.1] - 2021-02-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,6 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ## [unreleased]
 
-### Fixed
-
-- `moonstone/Viewport` to not pass `controlsRef` and `controlsMeasurements` to ui/ViewManager
-
 ## [4.0.0-alpha.1] - 2021-02-25
 
 -  The framework was updated to support React 17.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/Viewport` to delete `controlsRef` and `controlsMeasurements` from DOM
+- `moonstone/Viewport` to not pass `controlsRef` and `controlsMeasurements` to ui/ViewManager
 
 ## [4.0.0-alpha.1] - 2021-02-25
 

--- a/Panels/Viewport.js
+++ b/Panels/Viewport.js
@@ -169,6 +169,9 @@ const ViewportBase = class extends Component {
 			`Panels index, ${index}, is invalid for number of children, ${count}`
 		);
 
+		delete rest.controlsRef;
+		delete rest.controlsMeasurements;
+
 		return (
 			<ViewManager
 				{...rest}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
qa-sample for `pattern-video-layer` had an console error when clicking on the `menu` button from mediaControls. 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
I added `delete rest.controlsRef` and `delete rest.controlsMeasurements` in Panels/Viewport.js in order to remove them from the DOM.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
PLAT-139208

### Comments

Enact-DCO-1.0-Signed-off-by: Adrian Cocoara adrian.cocoara@lgepartner.com