### PR TITLE
PLAT-142797: Fix slider knob to be activated while dragging by touch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/Slider` to apply active style while dragging by touch
+
 ## [4.0.0] - 2021-04-08
 
 - The framework was updated to be compatible with Enact 4.0.0

--- a/Slider/Slider.module.less
+++ b/Slider/Slider.module.less
@@ -196,6 +196,26 @@
 			});
 		});
 
+		:global(.spotlight-input-touch) &.pressed {
+			.bar {
+				background-color: @moon-slider-active-bar-bg-color;			
+			}
+
+			.fill {
+				background-color: @moon-slider-active-fill-bg-color;
+			}
+
+			.load {
+				background-color: @moon-slider-active-load-bg-color;
+			}
+
+			.knob::before {
+				background-color:@moon-slider-active-knob-bg-color;
+				border-color: @moon-slider-active-knob-border-color;
+				transform: @knob-transform-active;
+			}
+		}
+
 		.disabled({
 			opacity: 1;
 


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist
* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`Slider` knob does not keep activated while dragging by touch.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Apply active style to knob while dragging by touch.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
PLAT-142797

### Comments