### PR TITLE
ENYO-5644: IncrementSlider: Update sampler to display Tooltip fully when Side is 'before' and Orientation is 'vertical'

### DIFF
--- a/samples/sampler/stories/default/IncrementSlider.js
+++ b/samples/sampler/stories/default/IncrementSlider.js
@@ -1,6 +1,7 @@
 import {action} from '@enact/storybook-utils/addons/actions';
 import {boolean, number, select} from '@enact/storybook-utils/addons/knobs';
 import {mergeComponentMetadata} from '@enact/storybook-utils';
+import ri from '@enact/ui/resolution';
 import {storiesOf} from '@storybook/react';
 
 import IncrementSlider, {IncrementSliderBase, IncrementSliderTooltip} from '@enact/moonstone/IncrementSlider';
@@ -33,7 +34,7 @@ storiesOf('Moonstone', module)
 					onChange={action('onChange')}
 					orientation={select('orientation', ['horizontal', 'vertical'], IncrementSliderConfig)}
 					step={number('step', IncrementSliderConfig)} // def: 1
-					style={{marginLeft: '96px',	marginRight: '96px'}}
+					style={{marginLeft: ri.scaleToRem(72), marginRight: ri.scaleToRem(72)}}
 				>
 					{tooltip ? (
 						<IncrementSliderTooltip

--- a/samples/sampler/stories/default/IncrementSlider.js
+++ b/samples/sampler/stories/default/IncrementSlider.js
@@ -33,6 +33,7 @@ storiesOf('Moonstone', module)
 					onChange={action('onChange')}
 					orientation={select('orientation', ['horizontal', 'vertical'], IncrementSliderConfig)}
 					step={number('step', IncrementSliderConfig)} // def: 1
+					style={{marginLeft: '96px',	marginRight: '96px'}}
 				>
 					{tooltip ? (
 						<IncrementSliderTooltip

--- a/samples/sampler/stories/default/ProgressBar.js
+++ b/samples/sampler/stories/default/ProgressBar.js
@@ -1,5 +1,6 @@
 import {boolean, number, select} from '@enact/storybook-utils/addons/knobs';
 import {mergeComponentMetadata, nullify} from '@enact/storybook-utils';
+import ri from '@enact/ui/resolution';
 import {storiesOf} from '@storybook/react';
 
 import ProgressBar, {ProgressBarTooltip} from '@enact/moonstone/ProgressBar';
@@ -29,6 +30,7 @@ storiesOf('Moonstone', module)
 					highlighted={boolean('highlighted', ProgressBarConfig)}
 					orientation={select('orientation', ['horizontal', 'vertical'], ProgressBarConfig, 'horizontal')}
 					progress={number('progress', ProgressBarConfig, {range: true, min: 0, max: 1, step: 0.01}, 0.4)}
+					style={{marginLeft: ri.scaleToRem(72), marginRight: ri.scaleToRem(72)}}
 				>
 					{tooltip ? (
 						<ProgressBarTooltip

--- a/samples/sampler/stories/default/Slider.js
+++ b/samples/sampler/stories/default/Slider.js
@@ -1,6 +1,7 @@
 import {action} from '@enact/storybook-utils/addons/actions';
 import {boolean, number, select} from '@enact/storybook-utils/addons/knobs';
 import {mergeComponentMetadata, nullify} from '@enact/storybook-utils';
+import ri from '@enact/ui/resolution';
 import {storiesOf} from '@storybook/react';
 
 import Slider, {SliderTooltip} from '@enact/moonstone/Slider';
@@ -37,6 +38,7 @@ storiesOf('Moonstone', module)
 					onChange={action('onChange')}
 					orientation={select('orientation', ['horizontal', 'vertical'], SliderConfig, 'horizontal')}
 					step={number('step', SliderConfig, 1)}
+					style={{marginLeft: ri.scaleToRem(72), marginRight: ri.scaleToRem(72)}}
 				>
 					{tooltip ? (
 						<SliderTooltip


### PR DESCRIPTION
In the sampler, the IncrementSlider sample doesn't display fully Tooltip.
Only the tip of the Tooltip is displayed.
This sample needs to be updated to fix it.

Enact-DCO-1.0-Signed-off-by: Yunho Lee (yunho2.lee@lge.com)