### PR TITLE
PLAT-145581: Remove web animation polyfill from samples

### DIFF
--- a/samples/perf-scroller-native/package.json
+++ b/samples/perf-scroller-native/package.json
@@ -38,7 +38,6 @@
     "classnames": "^2.2.6",
     "ilib": "^14.4.0",
     "react": "^17.0.1",
-    "react-dom": "^17.0.1",
-    "web-animations-js": "^2.3.2"
+    "react-dom": "^17.0.1"
   }
 }

--- a/samples/perf-scroller-native/src/index.js
+++ b/samples/perf-scroller-native/src/index.js
@@ -1,4 +1,3 @@
-import 'web-animations-js';
 import enactPkg from '@enact/core/package.json';
 import {render} from 'react-dom';
 

--- a/samples/perf-scroller-translate/package.json
+++ b/samples/perf-scroller-translate/package.json
@@ -39,7 +39,6 @@
     "classnames": "^2.2.6",
     "ilib": "^14.4.0",
     "react": "^17.0.1",
-    "react-dom": "^17.0.1",
-    "web-animations-js": "^2.3.2"
+    "react-dom": "^17.0.1"
   }
 }

--- a/samples/perf-scroller-translate/src/index.js
+++ b/samples/perf-scroller-translate/src/index.js
@@ -1,4 +1,3 @@
-import 'web-animations-js';
 import enactPkg from '@enact/core/package.json';
 import {render} from 'react-dom';
 

--- a/samples/perf-virtualgridlist-native/package.json
+++ b/samples/perf-virtualgridlist-native/package.json
@@ -37,7 +37,6 @@
     "@enact/ui": "^4.0.0",
     "ilib": "^14.4.0",
     "react": "^17.0.1",
-    "react-dom": "^17.0.1",
-    "web-animations-js": "^2.3.2"
+    "react-dom": "^17.0.1"
   }
 }

--- a/samples/perf-virtualgridlist-native/src/index.js
+++ b/samples/perf-virtualgridlist-native/src/index.js
@@ -1,4 +1,3 @@
-import 'web-animations-js';
 import enactPkg from '@enact/core/package.json';
 import {render} from 'react-dom';
 

--- a/samples/perf-virtualgridlist-translate/package.json
+++ b/samples/perf-virtualgridlist-translate/package.json
@@ -37,7 +37,6 @@
     "@enact/ui": "^4.0.0",
     "ilib": "^14.4.0",
     "react": "^17.0.1",
-    "react-dom": "^17.0.1",
-    "web-animations-js": "^2.3.2"
+    "react-dom": "^17.0.1"
   }
 }

--- a/samples/perf-virtualgridlist-translate/src/index.js
+++ b/samples/perf-virtualgridlist-translate/src/index.js
@@ -1,4 +1,3 @@
-import 'web-animations-js';
 import enactPkg from '@enact/core/package.json';
 import {render} from 'react-dom';
 

--- a/samples/perf-virtuallist-native-with-different-item-size/package.json
+++ b/samples/perf-virtuallist-native-with-different-item-size/package.json
@@ -37,7 +37,6 @@
     "@enact/ui": "^4.0.0",
     "ilib": "^14.4.0",
     "react": "^17.0.1",
-    "react-dom": "^17.0.1",
-    "web-animations-js": "^2.3.2"
+    "react-dom": "^17.0.1"
   }
 }

--- a/samples/perf-virtuallist-native-with-different-item-size/src/index.js
+++ b/samples/perf-virtuallist-native-with-different-item-size/src/index.js
@@ -1,4 +1,3 @@
-import 'web-animations-js';
 import enactPkg from '@enact/core/package.json';
 import {render} from 'react-dom';
 

--- a/samples/perf-virtuallist-native/package.json
+++ b/samples/perf-virtuallist-native/package.json
@@ -37,7 +37,6 @@
     "@enact/ui": "^4.0.0",
     "ilib": "^14.4.0",
     "react": "^17.0.1",
-    "react-dom": "^17.0.1",
-    "web-animations-js": "^2.3.2"
+    "react-dom": "^17.0.1"
   }
 }

--- a/samples/perf-virtuallist-native/src/index.js
+++ b/samples/perf-virtuallist-native/src/index.js
@@ -1,4 +1,3 @@
-import 'web-animations-js';
 import enactPkg from '@enact/core/package.json';
 import {render} from 'react-dom';
 

--- a/samples/perf-virtuallist-translate/package.json
+++ b/samples/perf-virtuallist-translate/package.json
@@ -37,7 +37,6 @@
     "@enact/ui": "^4.0.0",
     "ilib": "^14.4.0",
     "react": "^17.0.1",
-    "react-dom": "^17.0.1",
-    "web-animations-js": "^2.3.2"
+    "react-dom": "^17.0.1"
   }
 }

--- a/samples/perf-virtuallist-translate/src/index.js
+++ b/samples/perf-virtuallist-translate/src/index.js
@@ -1,4 +1,3 @@
-import 'web-animations-js';
 import enactPkg from '@enact/core/package.json';
 import {render} from 'react-dom';
 

--- a/samples/qa-a11y/package.json
+++ b/samples/qa-a11y/package.json
@@ -39,7 +39,6 @@
     "ilib": "^14.4.0",
     "prop-types": "^15.7.2",
     "react": "^17.0.1",
-    "react-dom": "^17.0.1",
-    "web-animations-js": "^2.3.2"
+    "react-dom": "^17.0.1"
   }
 }

--- a/samples/qa-a11y/src/index.js
+++ b/samples/qa-a11y/src/index.js
@@ -1,4 +1,3 @@
-import 'web-animations-js';
 import {render} from 'react-dom';
 
 import App from './App';

--- a/samples/qa-fonts/package.json
+++ b/samples/qa-fonts/package.json
@@ -38,7 +38,6 @@
     "ilib": "^14.4.0",
     "prop-types": "^15.7.2",
     "react": "^17.0.1",
-    "react-dom": "^17.0.1",
-    "web-animations-js": "^2.3.2"
+    "react-dom": "^17.0.1"
   }
 }

--- a/samples/qa-fonts/src/index.js
+++ b/samples/qa-fonts/src/index.js
@@ -1,4 +1,3 @@
-import 'web-animations-js';
 import {render} from 'react-dom';
 
 import App from './App';

--- a/samples/qa-i18n-async/package.json
+++ b/samples/qa-i18n-async/package.json
@@ -38,7 +38,6 @@
 		"ilib": "^14.4.0",
 		"prop-types": "^15.7.2",
 		"react": "^17.0.1",
-		"react-dom": "^17.0.1",
-		"web-animations-js": "^2.3.2"
+		"react-dom": "^17.0.1"
 	}
 }

--- a/samples/qa-i18n-async/src/index.js
+++ b/samples/qa-i18n-async/src/index.js
@@ -1,4 +1,3 @@
-import 'web-animations-js';
 import {render} from 'react-dom';
 import App from './App';
 

--- a/samples/qa-i18n/package.json
+++ b/samples/qa-i18n/package.json
@@ -39,7 +39,6 @@
 		"ilib": "^14.4.0",
 		"prop-types": "^15.7.2",
 		"react": "^17.0.1",
-		"react-dom": "^17.0.1",
-		"web-animations-js": "^2.3.2"
+		"react-dom": "^17.0.1"
 	}
 }

--- a/samples/qa-i18n/src/index.js
+++ b/samples/qa-i18n/src/index.js
@@ -1,4 +1,3 @@
-import 'web-animations-js';
 import {render} from 'react-dom';
 
 import App from './App';

--- a/samples/qa-scroller/package.json
+++ b/samples/qa-scroller/package.json
@@ -38,7 +38,6 @@
     "ilib": "^14.4.0",
     "prop-types": "^15.7.2",
     "react": "^17.0.1",
-    "react-dom": "^17.0.1",
-    "web-animations-js": "^2.3.2"
+    "react-dom": "^17.0.1"
   }
 }

--- a/samples/qa-scroller/src/index.js
+++ b/samples/qa-scroller/src/index.js
@@ -1,4 +1,3 @@
-import 'web-animations-js';
 import {render} from 'react-dom';
 
 import App from './App';

--- a/samples/qa-videoplayer/package.json
+++ b/samples/qa-videoplayer/package.json
@@ -43,7 +43,6 @@
 		"ilib": "^14.4.0",
 		"prop-types": "^15.7.2",
 		"react": "^17.0.1",
-		"react-dom": "^17.0.1",
-		"web-animations-js": "^2.3.2"
+		"react-dom": "^17.0.1"
 	}
 }

--- a/samples/qa-videoplayer/src/index.js
+++ b/samples/qa-videoplayer/src/index.js
@@ -1,4 +1,3 @@
-import 'web-animations-js';
 import {render} from 'react-dom';
 import App from './App';
 

--- a/samples/qa-virtualgridlist-preserve-focus/package.json
+++ b/samples/qa-virtualgridlist-preserve-focus/package.json
@@ -40,7 +40,6 @@
 		"react": "^17.0.1",
 		"react-dom": "^17.0.1",
 		"react-redux": "^7.2.0",
-		"redux": "^4.0.5",
-		"web-animations-js": "^2.3.2"
+		"redux": "^4.0.5"
 	}
 }

--- a/samples/qa-virtualgridlist-preserve-focus/src/index.js
+++ b/samples/qa-virtualgridlist-preserve-focus/src/index.js
@@ -1,4 +1,3 @@
-import 'web-animations-js';
 import {Provider} from 'react-redux';
 import {render} from 'react-dom';
 

--- a/samples/qa-virtualgridlist/package.json
+++ b/samples/qa-virtualgridlist/package.json
@@ -40,7 +40,6 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-redux": "^7.2.0",
-    "redux": "^4.0.5",
-    "web-animations-js": "^2.3.2"
+    "redux": "^4.0.5"
   }
 }

--- a/samples/qa-virtualgridlist/src/index.js
+++ b/samples/qa-virtualgridlist/src/index.js
@@ -1,4 +1,3 @@
-import 'web-animations-js';
 import {Provider} from 'react-redux';
 import {render} from 'react-dom';
 

--- a/samples/qa-virtuallist/package.json
+++ b/samples/qa-virtuallist/package.json
@@ -40,7 +40,6 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-redux": "^7.2.0",
-    "redux": "^4.0.5",
-    "web-animations-js": "^2.3.2"
+    "redux": "^4.0.5"
   }
 }

--- a/samples/qa-virtuallist/src/index.js
+++ b/samples/qa-virtuallist/src/index.js
@@ -1,4 +1,3 @@
-import 'web-animations-js';
 import {Provider} from 'react-redux';
 import {render} from 'react-dom';
 


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fix isomorphic test failure.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Remove web animation polyfill from samples as Web Animations API is also available in Safari browser.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
PLAT-145581

### Comments
