### PR TITLE
WRN-1268: Fix ContextualPopup to re-calcualte position when showCloseButton prop is updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/ContextualPopupDecorator` to reposition the popup when prop `showCloseButton` is updated and prop `direction` is left (right in RTL locales)
+
 ## [4.0.1] - 2021-06-28
 
 ### Fixed

--- a/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -293,7 +293,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 				this.adjustedDirection = this.props.direction;
 				// NOTE: `setState` is called and will cause re-render
 				this.positionContextualPopup();
-			} else if (this.props.direction === this.props.rtl ? 'right' : 'left' && prevProps.showCloseButton !== this.props.showCloseButton) {
+			} else if (this.props.direction === (this.props.rtl ? 'right' : 'left') && prevProps.showCloseButton !== this.props.showCloseButton) {
 				this.positionContextualPopup();
 			}
 

--- a/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -293,6 +293,8 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 				this.adjustedDirection = this.props.direction;
 				// NOTE: `setState` is called and will cause re-render
 				this.positionContextualPopup();
+			} else if (this.props.direction === this.props.rtl ? 'right' : 'left' && prevProps.showCloseButton !== this.props.showCloseButton) {
+				this.positionContextualPopup();
 			}
 
 			if (this.props.open && !prevProps.open) {


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fix `ContextualPopupDecorator` to re-calculate position of `ContextualPopup` when `showCloseButton` prop is updated

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Call `positionContextualPopup()` when `direction` is left and `showCloseButton` changed 

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRN-1268

### Comments
