### PR TITLE
WRN-3811: Migrate LabeledIconButton, Switch and SwitchItem unit tests to Testing Library

### DIFF
--- a/LabeledIconButton/tests/LabeledIconButton-specs.js
+++ b/LabeledIconButton/tests/LabeledIconButton-specs.js
@@ -1,59 +1,45 @@
-import {mount} from 'enzyme';
+import '@testing-library/jest-dom';
+import {render, screen} from '@testing-library/react';
+
 import LabeledIconButton from '../LabeledIconButton';
 
 describe('LabeledIconButton Voice Control Specs', () => {
-	test(
-		'should set "data-webos-voice-disabled" to IconButton',
-		() => {
-			const labeledIconButton = mount(
-				<LabeledIconButton data-webos-voice-disabled>star</LabeledIconButton>
-			);
+	test('should set "data-webos-voice-disabled" to IconButton', () => {
+		render(<LabeledIconButton data-webos-voice-disabled>star</LabeledIconButton>);
 
-			const expected = true;
-			const actual = labeledIconButton.find('[role="button"]').prop('data-webos-voice-disabled');
-			expect(actual).toBe(expected);
-		}
-	);
+		const expected = 'data-webos-voice-disabled';
+		const actual = screen.getByRole('button');
 
-	test(
-		'should set "data-webos-voice-group-label" to IconButton',
-		() => {
-			const voiceGroupLabel = 'voice group label';
-			const labeledIconButton = mount(
-				<LabeledIconButton data-webos-voice-group-label={voiceGroupLabel}>star</LabeledIconButton>
-			);
+		expect(actual).toHaveAttribute(expected);
+	});
 
-			const expected = voiceGroupLabel;
-			const actual = labeledIconButton.find('[role="button"]').prop('data-webos-voice-group-label');
-			expect(actual).toBe(expected);
-		}
-	);
+	test('should set "data-webos-voice-group-label" to IconButton', () => {
+		const voiceGroupLabel = 'voice group label';
+		render(<LabeledIconButton data-webos-voice-group-label={voiceGroupLabel}>star</LabeledIconButton>);
 
-	test(
-		'should set "data-webos-voice-label" to IconButton',
-		() => {
-			const voiceLabel = 'voice label';
-			const labeledIconButton = mount(
-				<LabeledIconButton data-webos-voice-label={voiceLabel}>star</LabeledIconButton>
-			);
+		const expected = voiceGroupLabel;
+		const actual = screen.getByRole('button');
 
-			const expected = voiceLabel;
-			const actual = labeledIconButton.find('[role="button"]').prop('data-webos-voice-label');
-			expect(actual).toBe(expected);
-		}
-	);
+		expect(actual).toHaveAttribute('data-webos-voice-group-label', expected);
+	});
 
-	test(
-		'should set "data-webos-voice-intent" to IconButton',
-		() => {
-			const voiceIntent = 'Select PlayContent';
-			const labeledIconButton = mount(
-				<LabeledIconButton data-webos-voice-intent={voiceIntent}>star</LabeledIconButton>
-			);
+	test('should set "data-webos-voice-label" to IconButton', () => {
+		const voiceLabel = 'voice label';
+		render(<LabeledIconButton data-webos-voice-label={voiceLabel}>star</LabeledIconButton>);
 
-			const expected = voiceIntent;
-			const actual = labeledIconButton.find('[role="button"]').prop('data-webos-voice-intent');
-			expect(actual).toBe(expected);
-		}
-	);
+		const expected = voiceLabel;
+		const actual = screen.getByRole('button');
+
+		expect(actual).toHaveAttribute('data-webos-voice-label', expected);
+	});
+
+	test('should set "data-webos-voice-intent" to IconButton', () => {
+		const voiceIntent = 'Select PlayContent';
+		render(<LabeledIconButton data-webos-voice-intent={voiceIntent}>star</LabeledIconButton>);
+
+		const expected = voiceIntent;
+		const actual = screen.getByRole('button');
+
+		expect(actual).toHaveAttribute('data-webos-voice-intent', expected);
+	});
 });

--- a/LabeledIconButton/tests/LabeledIconButton-specs.js
+++ b/LabeledIconButton/tests/LabeledIconButton-specs.js
@@ -4,6 +4,33 @@ import {render, screen} from '@testing-library/react';
 import LabeledIconButton from '../LabeledIconButton';
 
 describe('LabeledIconButton Voice Control Specs', () => {
+	test('should not have `selected` className by default', () => {
+		render(<LabeledIconButton>star</LabeledIconButton>);
+
+		const expected = 'selected';
+		const actual = screen.getByRole('button');
+
+		expect(actual).not.toHaveClass(expected);
+	});
+
+	test('should have `selected` className when selected is true', () => {
+		render(<LabeledIconButton selected>star</LabeledIconButton>);
+
+		const expected = 'selected';
+		const actual = screen.getByRole('button');
+
+		expect(actual).toHaveClass(expected);
+	});
+
+	test('should have `flipHorizontal` className when "flip" is set to "horizontal"', () => {
+		render(<LabeledIconButton flip="horizontal">star</LabeledIconButton>);
+
+		const expected = 'flipHorizontal';
+		const actual = screen.getByRole('button').children[1].children[0];
+
+		expect(actual).toHaveClass(expected);
+	});
+
 	test('should set "data-webos-voice-disabled" to IconButton', () => {
 		render(<LabeledIconButton data-webos-voice-disabled>star</LabeledIconButton>);
 

--- a/Switch/tests/Switch-specs.js
+++ b/Switch/tests/Switch-specs.js
@@ -4,34 +4,34 @@ import {fireEvent, render, screen} from '@testing-library/react';
 import Switch, {SwitchBase} from '../Switch';
 
 describe('Switch Specs', () => {
-    test('should have `animated` className', () => {
-        render(<SwitchBase>Toggle me</SwitchBase>);
+	test('should have `animated` className', () => {
+		render(<SwitchBase>Toggle me</SwitchBase>);
 
-        const expected = 'animated';
-        const actual = screen.getByText('Toggle me').parentElement;
+		const expected = 'animated';
+		const actual = screen.getByText('Toggle me').parentElement;
 
-        expect(actual).toHaveClass(expected);
-    });
+		expect(actual).toHaveClass(expected);
+	});
 
-    test('should not have `animated` className', () => {
-        render(<SwitchBase noAnimation>Toggle me</SwitchBase>);
+	test('should not have `animated` className', () => {
+		render(<SwitchBase noAnimation>Toggle me</SwitchBase>);
 
-        const unexpected = 'animated';
-        const actual = screen.getByText('Toggle me').parentElement;
+		const unexpected = 'animated';
+		const actual = screen.getByText('Toggle me').parentElement;
 
-        expect(actual).not.toHaveClass(unexpected);
-    });
+		expect(actual).not.toHaveClass(unexpected);
+	});
 
-    test('toggle Switch', () => {
-        const handleToggle = jest.fn();
-        render(<Switch onToggle={handleToggle}>Toggle me</Switch>);
+	test('toggle Switch', () => {
+		const handleToggle = jest.fn();
+		render(<Switch onToggle={handleToggle}>Toggle me</Switch>);
 
-        const actual = screen.getByText('Toggle me').parentElement;
+		const actual = screen.getByText('Toggle me').parentElement;
 
-        fireEvent.mouseDown(actual);
-        fireEvent.mouseUp(actual);
+		fireEvent.mouseDown(actual);
+		fireEvent.mouseUp(actual);
 
-        const expectedTimes = 1;
-        expect(handleToggle).toBeCalledTimes(expectedTimes);
-    });
+		const expectedTimes = 1;
+		expect(handleToggle).toBeCalledTimes(expectedTimes);
+	});
 });

--- a/Switch/tests/Switch-specs.js
+++ b/Switch/tests/Switch-specs.js
@@ -5,12 +5,12 @@ import Switch, {SwitchBase} from '../Switch';
 
 describe('Switch Specs', () => {
 	test('should not have `selected` className by default', () => {
-		render(<SwitchBase selected>Toggle me</SwitchBase>);
+		render(<SwitchBase>Toggle me</SwitchBase>);
 
 		const expected = 'selected';
 		const actual = screen.getByText('Toggle me').parentElement;
 
-		expect(actual).toHaveClass(expected);
+		expect(actual).not.toHaveClass(expected);
 	});
 
 	test('should have `selected` className when selected is true', () => {

--- a/Switch/tests/Switch-specs.js
+++ b/Switch/tests/Switch-specs.js
@@ -4,7 +4,25 @@ import {fireEvent, render, screen} from '@testing-library/react';
 import Switch, {SwitchBase} from '../Switch';
 
 describe('Switch Specs', () => {
-	test('should have `animated` className', () => {
+	test('should not have `selected` className by default', () => {
+		render(<SwitchBase selected>Toggle me</SwitchBase>);
+
+		const expected = 'selected';
+		const actual = screen.getByText('Toggle me').parentElement;
+
+		expect(actual).toHaveClass(expected);
+	});
+
+	test('should have `selected` className when selected is true', () => {
+		render(<SwitchBase selected>Toggle me</SwitchBase>);
+
+		const expected = 'selected';
+		const actual = screen.getByText('Toggle me').parentElement;
+
+		expect(actual).toHaveClass(expected);
+	});
+
+	test('should have `animated` className by default', () => {
 		render(<SwitchBase>Toggle me</SwitchBase>);
 
 		const expected = 'animated';
@@ -13,7 +31,7 @@ describe('Switch Specs', () => {
 		expect(actual).toHaveClass(expected);
 	});
 
-	test('should not have `animated` className', () => {
+	test('should not have `animated` className when noAnimation is true', () => {
 		render(<SwitchBase noAnimation>Toggle me</SwitchBase>);
 
 		const unexpected = 'animated';

--- a/Switch/tests/Switch-specs.js
+++ b/Switch/tests/Switch-specs.js
@@ -1,0 +1,37 @@
+import '@testing-library/jest-dom';
+import {fireEvent, render, screen} from '@testing-library/react';
+
+import Switch, {SwitchBase} from '../Switch';
+
+describe('Switch Specs', () => {
+    test('should have `animated` className', () => {
+        render(<SwitchBase>Toggle me</SwitchBase>);
+
+        const expected = 'animated';
+        const actual = screen.getByText('Toggle me').parentElement;
+
+        expect(actual).toHaveClass(expected);
+    });
+
+    test('should not have `animated` className', () => {
+        render(<SwitchBase noAnimation>Toggle me</SwitchBase>);
+
+        const unexpected = 'animated';
+        const actual = screen.getByText('Toggle me').parentElement;
+
+        expect(actual).not.toHaveClass(unexpected);
+    });
+
+    test('toggle Switch', () => {
+        const handleToggle = jest.fn();
+        render(<Switch onToggle={handleToggle}>Toggle me</Switch>);
+
+        const actual = screen.getByText('Toggle me').parentElement;
+
+        fireEvent.mouseDown(actual);
+        fireEvent.mouseUp(actual);
+
+        const expectedTimes = 1;
+        expect(handleToggle).toBeCalledTimes(expectedTimes);
+    });
+});

--- a/SwitchItem/tests/SwitchItem-specs.js
+++ b/SwitchItem/tests/SwitchItem-specs.js
@@ -3,7 +3,7 @@ import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import SwitchItem from '../SwitchItem';
-import {SwitchItemBase} from "../../../sandstone/SwitchItem";
+import {SwitchItemBase} from '../../../sandstone/SwitchItem';
 
 describe('SwitchItem Specs', () => {
 	test('should contain a Switch', () => {

--- a/SwitchItem/tests/SwitchItem-specs.js
+++ b/SwitchItem/tests/SwitchItem-specs.js
@@ -9,27 +9,16 @@ describe('SwitchItem Specs', () => {
 		render(<SwitchItemBase />);
 
 		const expected = 'switch';
-		const actual = screen.getAllByRole('button')[1];
+		const actual = screen.getByRole('checkbox').children[2].children[0];
 
 		expect(actual).toHaveClass(expected);
-	});
-
-	test('should pass selected to Switch element', () => {
-		render(<SwitchItemBase selected />);
-
-		const expected = 'selected';
-		const SwitchItemElement = screen.getAllByRole('button')[0];
-		const SwitchElement = screen.getAllByRole('button')[1];
-
-		expect(SwitchItemElement).toHaveClass(expected);
-		expect(SwitchElement).toHaveClass(expected);
 	});
 
 	test('should pass disabled to Switch element', () => {
 		render(<SwitchItemBase disabled />);
 
 		const expected = 'true';
-		const SwitchItemElement = screen.getAllByRole('button')[0];
+		const SwitchItemElement = screen.getByRole('checkbox');
 
 		expect(SwitchItemElement).toHaveAttribute('aria-disabled', expected);
 	});

--- a/SwitchItem/tests/SwitchItem-specs.js
+++ b/SwitchItem/tests/SwitchItem-specs.js
@@ -14,6 +14,15 @@ describe('SwitchItem Specs', () => {
 		expect(actual).toHaveClass(expected);
 	});
 
+	test('should pass selected to Switch element', () => {
+		render(<SwitchItemBase selected />);
+
+		const expected = 'selected';
+		const SwitchElement = screen.getByRole('checkbox').children[2].children[0];
+
+		expect(SwitchElement).toHaveClass(expected);
+	});
+
 	test('should pass disabled to Switch element', () => {
 		render(<SwitchItemBase disabled />);
 

--- a/SwitchItem/tests/SwitchItem-specs.js
+++ b/SwitchItem/tests/SwitchItem-specs.js
@@ -1,51 +1,58 @@
-import {mount} from 'enzyme';
+import '@testing-library/jest-dom';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
 import SwitchItem from '../SwitchItem';
+import {SwitchItemBase} from "../../../sandstone/SwitchItem";
 
 describe('SwitchItem Specs', () => {
-
 	test('should contain a Switch', () => {
+		render(<SwitchItemBase />);
 
-		const switchItem = mount(
-			<SwitchItem>
-				SwitchItem
-			</SwitchItem>
-		);
+		const expected = 'switch';
+		const actual = screen.getAllByRole('button')[1];
 
-		const expected = 1;
-		const actual = switchItem.find('Switch').length;
-
-		expect(actual).toBe(expected);
+		expect(actual).toHaveClass(expected);
 	});
 
 	test('should pass selected to Switch element', () => {
+		render(<SwitchItemBase selected />);
 
-		const switchItem = mount(
-			<SwitchItem selected>
-				SwitchItem
-			</SwitchItem>
-		);
+		const expected = 'selected';
+		const SwitchItemElement = screen.getAllByRole('button')[0];
+		const SwitchElement = screen.getAllByRole('button')[1];
 
-		const SwitchComponent = switchItem.find('Switch');
-
-		const expected = true;
-		const actual = SwitchComponent.prop('selected');
-
-		expect(actual).toBe(expected);
+		expect(SwitchItemElement).toHaveClass(expected);
+		expect(SwitchElement).toHaveClass(expected);
 	});
 
 	test('should pass disabled to Switch element', () => {
+		render(<SwitchItemBase disabled />);
 
-		const switchItem = mount(
-			<SwitchItem disabled>
-				SwitchItem
-			</SwitchItem>
-		);
+		const expected = 'true';
+		const SwitchItemElement = screen.getAllByRole('button')[0];
 
-		const SwitchComponent = switchItem.find('Switch');
+		expect(SwitchItemElement).toHaveAttribute('aria-disabled', expected);
+	});
 
-		const expected = true;
-		const actual = SwitchComponent.prop('disabled');
+	test('should toggle Switch', () => {
+		const handleToggle = jest.fn();
+		render(<SwitchItem onToggle={handleToggle} />);
 
-		expect(actual).toBe(expected);
+		const actual = screen.getByRole('checkbox');
+
+		userEvent.click(actual);
+
+		expect(actual).toBeChecked();
+
+		const expectedTimes = 1;
+		expect(handleToggle).toBeCalledTimes(expectedTimes);
+	});
+
+	test('should render correct children', () => {
+		render(<SwitchItem>Hello SwitchItem</SwitchItem>);
+		const Child = screen.getByText(/Hello SwitchItem/i);
+
+		expect(Child).toBeInTheDocument();
 	});
 });

--- a/SwitchItem/tests/SwitchItem-specs.js
+++ b/SwitchItem/tests/SwitchItem-specs.js
@@ -2,8 +2,7 @@ import '@testing-library/jest-dom';
 import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import SwitchItem from '../SwitchItem';
-import {SwitchItemBase} from '../../../sandstone/SwitchItem';
+import SwitchItem, {SwitchItemBase} from '../SwitchItem';
 
 describe('SwitchItem Specs', () => {
 	test('should contain a Switch', () => {


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Stanca Pop stanca.pop@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Migrated unit tests from Enzyme to Testing Library for LabeledIconButton, Switch and SwitchItem components.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRN-3811

### Comments
