### PR TITLE
WRN-3838: Migrated units tests for Picker, RangePicker and Spinner to testing-library

### DIFF
--- a/Picker/tests/Picker-specs.js
+++ b/Picker/tests/Picker-specs.js
@@ -1,70 +1,72 @@
-import {mount} from 'enzyme';
+import '@testing-library/jest-dom';
+import {render, screen} from '@testing-library/react';
+
 import {Picker, PickerBase} from '../Picker';
 
 describe('Picker Specs', () => {
 	test('should render selected child wrapped with <PickerItem/>', () => {
-		const picker = mount(
+		render(
 			<Picker value={1}>
 				{[1, 2, 3, 4]}
 			</Picker>
 		);
+		const pickerText = screen.getByText('2').parentElement.parentElement;
 
-		const expected = '2';
-		const actual = picker.find('PickerItem').text();
+		const expected = 'item';
 
-		expect(actual).toBe(expected);
+		expect(pickerText).toHaveClass(expected);
 	});
 
-	test(
-		'should set the max of <Picker> to be one less than the number of children',
-		() => {
-			const picker = mount(
-				<Picker value={1}>
-					{[1, 2, 3, 4]}
-				</Picker>
-			);
+	test('should set the max of <Picker> to be one less than the number of children', () => {
+		render(
+			<Picker value={3}>
+				{[1, 2, 3, 4]}
+			</Picker>
+		);
+		const arrowForward = screen.getAllByRole('button')[0];
 
-			const expected = 3;
-			const actual = picker.find('Picker').last().prop('max');
+		const expectedValue = 'true';
+		const expectedAttribute = 'aria-disabled';
 
-			expect(actual).toBe(expected);
-		}
-	);
+		expect(arrowForward).toHaveAttribute(expectedAttribute, expectedValue);
+	});
 
 	test('should be disabled when empty', () => {
-		const picker = mount(
+		render(
 			<PickerBase>
 				{[]}
 			</PickerBase>
 		);
+		const picker = screen.getAllByRole('button')[0].parentElement;
 
-		const actual = picker.find('Picker').last().prop('disabled');
-		expect(actual).toBe(true);
+		const expected = 'disabled';
+
+		expect(picker).toHaveAttribute(expected);
 	});
 
 	test('should set "data-webos-voice-disabled" to decrement button when voice control is disabled', () => {
-		const picker = mount(
+		render(
 			<PickerBase data-webos-voice-disabled>
 				{[1, 2, 3, 4]}
 			</PickerBase>
 		);
+		const picker = screen.getAllByRole('button')[1];
 
-		const expected = true;
-		const actual = picker.find('PickerButton').at(0).prop('data-webos-voice-disabled');
+		const expected = 'data-webos-voice-disabled';
 
-		expect(actual).toBe(expected);
+		expect(picker).toHaveAttribute(expected);
 	});
 
 	test('should set "data-webos-voice-disabled" to increment button when voice control is disabled', () => {
-		const picker = mount(
+		render(
 			<PickerBase data-webos-voice-disabled>
 				{[1, 2, 3, 4]}
 			</PickerBase>
 		);
+		const picker = screen.getAllByRole('button')[0];
 
-		const expected = true;
-		const actual = picker.find('PickerButton').at(1).prop('data-webos-voice-disabled');
+		const expected = 'data-webos-voice-disabled';
 
-		expect(actual).toBe(expected);
+		expect(picker).toHaveAttribute(expected);
 	});
 });

--- a/RangePicker/tests/RangePicker-specs.js
+++ b/RangePicker/tests/RangePicker-specs.js
@@ -1,79 +1,73 @@
-import {mount} from 'enzyme';
-import {RangePicker, RangePickerBase} from '../RangePicker';
+import '@testing-library/jest-dom';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
-const tap = (node) => {
-	node.simulate('mousedown');
-	node.simulate('mouseup');
-};
-const decrement = (slider) => tap(slider.find('IconButton').last());
-const increment = (slider) => tap(slider.find('IconButton').first());
+import {RangePicker, RangePickerBase} from '../RangePicker';
 
 describe('RangePicker Specs', () => {
 	test('should render a single child with the current value', () => {
-		const picker = mount(
-			<RangePicker min={-10} max={20} value={10} />
-		);
+		render(<RangePicker min={-10} max={20} value={10} />);
+		const textField = screen.getByText('10');
 
-		const expected = '10';
-		const actual = picker.find('PickerItem').text();
+		const expected = 'item';
 
-		expect(actual).toBe(expected);
+		expect(textField).toBeInTheDocument();
+		expect(textField).toHaveClass(expected);
 	});
 
 	test('should increase by step amount on increment press', () => {
-		const picker = mount(
-			<RangePicker min={0} max={100} defaultValue={10} step={1} noAnimation />
-		);
+		render(<RangePicker min={0} max={100} defaultValue={10} step={1} noAnimation />);
+		const incrementButton = screen.getByLabelText('10 next item');
 
-		increment(picker);
+		userEvent.click(incrementButton);
 
-		const expected = '11';
-		const actual = picker.find('PickerItem').first().text();
+		const textField = screen.getByText('11');
+		const expected = 'item';
 
-		expect(actual).toBe(expected);
+		expect(textField).toBeInTheDocument();
+		expect(textField).toHaveClass(expected);
 	});
 
 	test('should decrease by step amount on decrement press', () => {
-		const picker = mount(
-			<RangePicker min={0} max={100} defaultValue={10} step={1} noAnimation />
-		);
+		render(<RangePicker min={0} max={100} defaultValue={10} step={1} noAnimation />);
+		const decrementButton = screen.getByLabelText('10 previous item');
 
-		decrement(picker);
+		userEvent.click(decrementButton);
 
-		const expected = '9';
-		const actual = picker.find('PickerItem').first().text();
+		const textField = screen.getByText('9');
+		const expected = 'item';
 
-		expect(actual).toBe(expected);
+		expect(textField).toBeInTheDocument();
+		expect(textField).toHaveClass(expected);
 	});
 
 	test('should pad the value', () => {
-		const picker = mount(
-			<RangePicker min={0} max={100} value={10} step={1} padded />
-		);
+		render(<RangePicker min={0} max={100} value={10} step={1} padded />);
+		const textField = screen.getByText('010');
 
-		const expected = '010';
-		const actual = picker.find('PickerItem').text();
+		const expected = 'item';
 
-		expect(actual).toBe(expected);
+		expect(textField).toBeInTheDocument();
+		expect(textField).toHaveClass(expected);
 	});
 
 	test('should pad the value when min has more digits than max', () => {
-		const picker = mount(
-			<RangePicker min={-1000} max={100} value={10} step={1} padded />
-		);
+		render(<RangePicker min={-1000} max={100} value={10} step={1} padded />);
+		const textField = screen.getByText('0010');
 
-		const expected = '0010';
-		const actual = picker.find('PickerItem').text();
+		const expected = 'item';
 
-		expect(actual).toBe(expected);
+		expect(textField).toBeInTheDocument();
+		expect(textField).toHaveClass(expected);
 	});
 
 	test('should be disabled when limited to a single value', () => {
-		const picker = mount(
-			<RangePickerBase min={0} max={0} value={0} />
-		);
+		render(<RangePickerBase min={0} max={0} value={0} />);
+		const rangePicker = screen.getAllByRole('button')[0].parentElement;
 
-		const actual = picker.find('Picker').last().prop('disabled');
-		expect(actual).toBe(true);
+		const expectedAttribute = 'aria-disabled';
+		const expectedValue = 'true';
+
+		expect(rangePicker).toHaveAttribute(expectedAttribute, expectedValue);
 	});
 });

--- a/Spinner/tests/Spinner-specs.js
+++ b/Spinner/tests/Spinner-specs.js
@@ -1,83 +1,52 @@
-import {mount} from 'enzyme';
+import '@testing-library/jest-dom';
+import {render, screen} from '@testing-library/react';
+
 import Spinner from '../Spinner';
-import css from '../Spinner.module.less';
 
 describe('Spinner Specs', () => {
-	test(
-		'should not have client node when Spinner has no children',
-		() => {
-			const spinner = mount(
-				<Spinner />
-			);
+	test('should not have client node when Spinner has no children', () => {
+		render(<Spinner />);
+		const spinner = screen.getByRole('alert');
+		const children = spinner.children;
 
-			const expected = false;
-			const actual = spinner.find(`div.${css.client}`).exists();
-
-			expect(actual).toBe(expected);
-		}
-	);
+		expect(children.length).toEqual(1);
+		expect(children.item(0)).toHaveClass('bg');
+		expect(children.item(1)).not.toBeInTheDocument();
+	});
 
 	test('should have a client node when Spinner has children', () => {
-		const spinner = mount(
-			<Spinner>
-				Loading...
-			</Spinner>
-		);
+		render(<Spinner>Loading...</Spinner>);
+		const spinner = screen.getByRole('alert');
+		const childClient = spinner.children.item(1);
 
-		const expected = true;
-		const actual = spinner.find(`div.${css.client}`).exists();
-
-		expect(actual).toBe(expected);
+		expect(childClient).toHaveClass('client');
 	});
 
 	test('should have content class when Spinner has children', () => {
-		const spinner = mount(
-			<Spinner>
-				Loading...
-			</Spinner>
-		);
+		render(<Spinner>Loading...</Spinner>);
+		const spinner = screen.getByRole('alert');
 
-		const expected = true;
-		const actual = spinner.find(`div.${css.spinner}`).hasClass(css.content);
-
-		expect(actual).toBe(expected);
+		expect(spinner).toHaveClass('content');
 	});
 
-	test(
-		'should have transparent class when transparent prop equals true',
-		() => {
-			const spinner = mount(
-				<Spinner transparent>
-					Loading...
-				</Spinner>
-			);
+	test('should have transparent class when transparent prop equals true', () => {
+		render(<Spinner transparent>Loading...</Spinner>);
+		const spinner = screen.getByRole('alert');
 
-			const expected = true;
-			const actual = spinner.find(`div.${css.spinner}`).hasClass(css.transparent);
-
-			expect(actual).toBe(expected);
-		}
-	);
+		expect(spinner).toHaveClass('transparent');
+	});
 
 	test('should set role to alert by default', () => {
-		const spinner = mount(
-			<Spinner />
-		);
+		render(<Spinner />);
+		const spinner = screen.getByLabelText('Loading');
 
-		const expected = 'alert';
-		const actual = spinner.find(`div.${css.spinner}`).prop('role');
-
-		expect(actual).toBe(expected);
+		expect(spinner).toHaveAttribute('role', 'alert');
 	});
 
 	test('should set aria-live to off by default', () => {
-		const spinner = mount(
-			<Spinner />
-		);
+		render(<Spinner />);
+		const spinner = screen.getByRole('alert');
 
-		const expected = 'off';
-		const actual = spinner.find(`div.${css.spinner}`).prop('aria-live');
-
-		expect(actual).toBe(expected);
+		expect(spinner).toHaveAttribute('aria-live', 'off');
 	});
 });


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Migrated units tests for Picker, RangePicker and Spinner to testing-library

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-3838

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian daniel.stoian@lgepartner.com