### PR TITLE
WRN-3836: Migrate Panels:Breadcrumb and BreadcrumbDecorator unit tests to Testing Library

### DIFF
--- a/Panels/tests/Breadcrumb-specs.js
+++ b/Panels/tests/Breadcrumb-specs.js
@@ -1,15 +1,16 @@
-import {mount} from 'enzyme';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
 import Breadcrumb from '../Breadcrumb';
 
 describe('Breadcrumb', () => {
 
 	test.skip('should include {index} in the payload of {onSelect}', () => {
 		const handleSelect = jest.fn();
-		const subject = mount(
-			<Breadcrumb index={3} onSelect={handleSelect} />
-		);
+		render(<Breadcrumb index={3} onSelect={handleSelect} />);
 
-		subject.simulate('click', {});
+		const breadCrumb = screen.getByLabelText('GO TO PREVIOUS');
+		userEvent.click(breadCrumb);
 
 		const expected = 3;
 		const actual = handleSelect.mock.calls[0][0].index;
@@ -17,22 +18,18 @@ describe('Breadcrumb', () => {
 		expect(actual).toBe(expected);
 	});
 
-	test.skip(
-		'should include call both the {onClick} and {onSelect} handlers on click',
-		() => {
-			const handleSelect = jest.fn();
-			const handleClick = jest.fn();
-			const subject = mount(
-				<Breadcrumb index={3} onClick={handleClick} onSelect={handleSelect} />
-			);
+	test.skip('should include call both the {onClick} and {onSelect} handlers on click', () => {
+		const handleSelect = jest.fn();
+		const handleClick = jest.fn();
+		render(<Breadcrumb index={3} onClick={handleClick} onSelect={handleSelect} />);
 
-			subject.simulate('click', {});
+		const breadCrumb = screen.getByLabelText('GO TO PREVIOUS');
+		userEvent.click(breadCrumb);
 
-			const expected = true;
-			const actual = handleSelect.mock.calls.length === 1 &&
-					handleClick.mock.calls.length === 1;
+		const expected = true;
+		const actual = handleSelect.mock.calls.length === 1 &&
+			handleClick.mock.calls.length === 1;
 
-			expect(actual).toBe(expected);
-		}
-	);
+		expect(actual).toBe(expected);
+	});
 });

--- a/Panels/tests/Breadcrumb-specs.js
+++ b/Panels/tests/Breadcrumb-specs.js
@@ -4,7 +4,6 @@ import userEvent from '@testing-library/user-event';
 import Breadcrumb from '../Breadcrumb';
 
 describe('Breadcrumb', () => {
-
 	test.skip('should include {index} in the payload of {onSelect}', () => {
 		const handleSelect = jest.fn();
 		render(<Breadcrumb index={3} onSelect={handleSelect} />);

--- a/Panels/tests/BreadcrumbDecorator-specs.js
+++ b/Panels/tests/BreadcrumbDecorator-specs.js
@@ -5,7 +5,6 @@ import BreadcrumbDecorator from '../BreadcrumbDecorator';
 import Panels from '../Panels';
 
 describe('BreadcrumbDecorator', () => {
-
 	const Panel = () => <div />;
 
 	test('should wrap primitive breadcrumbs with Breadcrumb', () => {

--- a/Panels/tests/BreadcrumbDecorator-specs.js
+++ b/Panels/tests/BreadcrumbDecorator-specs.js
@@ -1,5 +1,5 @@
-import {render, screen} from '@testing-library/react';
 import '@testing-library/jest-dom';
+import {render, screen} from '@testing-library/react';
 
 import BreadcrumbDecorator from '../BreadcrumbDecorator';
 import Panels from '../Panels';
@@ -130,6 +130,7 @@ describe('BreadcrumbDecorator', () => {
 		const expected = 'test_bc_2';
 		const actual = screen.getByText(/03/).parentElement;
 
+		// aria-owns is not visible in the DOM, so the id is used instead
 		expect(actual).toHaveAttribute('id', expected);
 	});
 });


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Adrian Cocoara adrian.cocoara@lgepartner.com

### Checklist
* [X] I have read and understand the contribution guide
* [ ] A CHANGELOG entry is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Migrated `Breadcrumb` and `BreadcrumbDecorator` unit tests to react-testing-library

### Resolution

### Additional Considerations
Before migrating to react-testing-library, all tests for `BreadcrumbDecorator` were skipped because at the time they were created enzyme couldn't handle some tests. After migrating to react-testing-library all tests pass, so none of them are skipped any more

### Links
WRN-3834

### Comments