### PR TITLE
WRN-3837: [Moonstone] Migrate Panels:Header, IndexedBreadcrumb and Panels unit tests to Testing Library

### DIFF
--- a/Panels/tests/Header-specs.js
+++ b/Panels/tests/Header-specs.js
@@ -1,42 +1,39 @@
-import {mount} from 'enzyme';
+import '@testing-library/jest-dom';
+import {render, screen} from '@testing-library/react';
+
 import Header from '../Header';
-import css from '../Header.module.less';
 
 describe('Header Specs', () => {
-
 	test('should render with title text without changing case', () => {
 		let msg = 'cRaZy-cased super Header';
-
-		const header = mount(
+		render(
 			<Header><title>{msg}</title></Header>
 		);
 
-		const expected = msg;
-		const actual = header.find('h1').text();
+		const titleText = screen.getByText(msg)
 
-		expect(actual).toBe(expected);
+		expect(titleText).toBeInTheDocument();
 	});
 
 	test('should have fullBleed class applied', () => {
-		const header = mount(
+		render(
 			<Header fullBleed>
 				<title>Header</title>
 			</Header>
 		);
 
-		const expected = true;
-		const actual = header.find('header').hasClass(css.fullBleed);
+		const headerElement = screen.getByLabelText('Header');
 
-		expect(actual).toBe(expected);
+		expect(headerElement).toHaveClass('fullBleed');
 	});
 
 	test('should inject a custom component when headerInput is used', () => {
-		const Input = () => <input />;
+		const Input = () => <input data-testid="input" />;
 
 		// This just uses an <input> tag for easy discoverability. It should behave the same way
 		// as a moonstone/Input, the standard here, but that would require importing a diffenent
 		// component than what we're testing here.
-		const header = mount(
+		render(
 			<Header>
 				<title>Header</title>
 				<headerInput>
@@ -45,9 +42,8 @@ describe('Header Specs', () => {
 			</Header>
 		);
 
-		const expected = 1;
-		const actual = header.find('input');
+		const inputElement = screen.getByTestId('input');
 
-		expect(actual).toHaveLength(expected);
+		expect(inputElement).toBeInTheDocument();
 	});
 });

--- a/Panels/tests/Header-specs.js
+++ b/Panels/tests/Header-specs.js
@@ -10,7 +10,7 @@ describe('Header Specs', () => {
 			<Header><title>{msg}</title></Header>
 		);
 
-		const titleText = screen.getByText(msg)
+		const titleText = screen.getByText(msg);
 
 		expect(titleText).toBeInTheDocument();
 	});

--- a/Panels/tests/Header-specs.js
+++ b/Panels/tests/Header-specs.js
@@ -6,9 +6,7 @@ import Header from '../Header';
 describe('Header Specs', () => {
 	test('should render with title text without changing case', () => {
 		let msg = 'cRaZy-cased super Header';
-		render(
-			<Header><title>{msg}</title></Header>
-		);
+		render(<Header><title>{msg}</title></Header>);
 
 		const titleText = screen.getByText(msg);
 
@@ -16,11 +14,7 @@ describe('Header Specs', () => {
 	});
 
 	test('should have fullBleed class applied', () => {
-		render(
-			<Header fullBleed>
-				<title>Header</title>
-			</Header>
-		);
+		render(<Header fullBleed><title>Header</title></Header>);
 
 		const headerElement = screen.getByLabelText('Header');
 

--- a/Panels/tests/IndexedBreadcrumbs-specs.js
+++ b/Panels/tests/IndexedBreadcrumbs-specs.js
@@ -4,7 +4,6 @@ import userEvent from '@testing-library/user-event';
 import IndexedBreadcrumbs from '../IndexedBreadcrumbs';
 
 describe('IndexedBreadcrumbs', () => {
-
 	// Suite-wide setup
 
 	test('should generate {index} breadcrumbs when {index} <= {max}', () => {

--- a/Panels/tests/IndexedBreadcrumbs-specs.js
+++ b/Panels/tests/IndexedBreadcrumbs-specs.js
@@ -40,13 +40,9 @@ describe('IndexedBreadcrumbs', () => {
 
 	test.skip('should call {onBreadcrumbClick} once when breadcrumb is clicked', () => {
 		const handleClick = jest.fn();
-		render(
-			<nav>
-				{IndexedBreadcrumbs('id', 1, 1, handleClick)}
-			</nav>
-		);
-
+		render(<nav>{IndexedBreadcrumbs('id', 1, 1, handleClick)}</nav>);
 		const breadcrumb = screen.getByLabelText('GO TO PREVIOUS');
+
 		userEvent.click(breadcrumb);
 
 		expect(handleClick).toHaveBeenCalled();

--- a/Panels/tests/IndexedBreadcrumbs-specs.js
+++ b/Panels/tests/IndexedBreadcrumbs-specs.js
@@ -1,4 +1,6 @@
-import {mount} from 'enzyme';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
 import IndexedBreadcrumbs from '../IndexedBreadcrumbs';
 
 describe('IndexedBreadcrumbs', () => {
@@ -37,23 +39,17 @@ describe('IndexedBreadcrumbs', () => {
 		expect(actual).toBe(expected);
 	});
 
-	test.skip(
-		'should call {onBreadcrumbClick} once when breadcrumb is clicked',
-		() => {
-			const handleClick = jest.fn();
-			const subject = mount(
-				<nav>
-					{IndexedBreadcrumbs('id', 1, 1, handleClick)}
-				</nav>
-			);
+	test.skip('should call {onBreadcrumbClick} once when breadcrumb is clicked', () => {
+		const handleClick = jest.fn();
+		render(
+			<nav>
+				{IndexedBreadcrumbs('id', 1, 1, handleClick)}
+			</nav>
+		);
 
-			subject.find('Breadcrumb').simulate('click', {});
+		const breadcrumb = screen.getByLabelText('GO TO PREVIOUS');
+		userEvent.click(breadcrumb);
 
-			const expected = 1;
-			const actual = handleClick.mock.calls.length;
-
-			expect(actual).toBe(expected);
-		}
-	);
-
+		expect(handleClick).toHaveBeenCalled();
+	});
 });

--- a/Panels/tests/Panels-specs.js
+++ b/Panels/tests/Panels-specs.js
@@ -34,9 +34,7 @@ describe('Panels Specs', () => {
 
 	test('should set application close button "aria-label" to closeButtonAriaLabel', () => {
 		const label = 'custom close button label';
-		render(
-			<Panels closeButtonAriaLabel={label} />
-		);
+		render(<Panels closeButtonAriaLabel={label} />);
 
 		const applicationCloseButton = screen.getByRole('button');
 
@@ -84,14 +82,14 @@ describe('Panels Specs', () => {
 		const {rerender} = render(
 			<Panels index={0}>
 				<DivPanel />
-				<DivPanel id="p2" autoFocus="last-focused" />
+				<DivPanel autoFocus="last-focused" id="p2" />
 			</Panels>
 		);
 
 		rerender(
 			<Panels index={1}>
 				<DivPanel />
-				<DivPanel id="p2" autoFocus="last-focused" />
+				<DivPanel autoFocus="last-focused" id="p2" />
 			</Panels>
 		);
 


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Adrian Cocoara adrian.cocoara@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Migrated `Header`, `IndexedBreadcrumb` and `Panels` to react-testing-library  

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Before migrating to react-testing-library, all tests for `Panels were skipped because at the time they were created enzyme couldn't handle some tests. After migrating to react-testing-library all tests pass, so none of them are skipped any more

### Links
[//]: # (Related issues, references)
WRN-3837

### Comments
