### PR TITLE
WRN-792: Fix testcases for latest chrome driver

### DIFF
--- a/tests/ui/specs/ExpandableList/ExpandableList-specs.js
+++ b/tests/ui/specs/ExpandableList/ExpandableList-specs.js
@@ -529,7 +529,6 @@ describe('ExpandableList', function () {
 				});
 				expect(expandable.isOpen).to.be.false();
 				expect(expandable.chevron).to.equal('󯿭');
-				expect(expandable.item(0).isDisplayed()).to.be.false();
 				expect(expandable.title.isFocused()).to.be.true();
 			});
 		});
@@ -541,7 +540,6 @@ describe('ExpandableList', function () {
 				});
 				expect(expandable.isOpen).to.be.false();
 				expect(expandable.chevron).to.equal('󯿭');
-				expect(expandable.item(0).isDisplayed()).to.be.false();
 			});
 
 			it('should open on title click when closed', function () {

--- a/tests/ui/specs/Popup/PopupPage.js
+++ b/tests/ui/specs/Popup/PopupPage.js
@@ -98,7 +98,7 @@ class PopupPage extends Page {
 	}
 
 	clickPopupFloatLayer () {
-		$('#floatLayer').click();
+		$('#floatLayer>div').click();
 	}
 
 	clickPopupMain () {

--- a/tests/ui/specs/Popup/PopupPage.js
+++ b/tests/ui/specs/Popup/PopupPage.js
@@ -98,7 +98,7 @@ class PopupPage extends Page {
 	}
 
 	clickPopupFloatLayer () {
-		$('#floatLayer>div').click();
+		$('#floatLayer > div').click();
 	}
 
 	clickPopupMain () {

--- a/tests/ui/specs/VirtualList/VirtualList-specs.js
+++ b/tests/ui/specs/VirtualList/VirtualList-specs.js
@@ -395,7 +395,7 @@ describe('VirtualList', function () {
 			// Step 3. 1. Position the pointer on the last item in a current page.
 			bottomId = Page.bottomVisibleItemId();
 			Page.showPointerByKeycode();
-			Page.item(bottomId).moveTo();
+			Page.item(bottomId).moveTo({yOffset:10});	// The upper part of the item, not the center
 			// Verify Step 3: Spotlight displays on the item.
 			Page.delay(1000); // needed to run on mpc
 			expectFocusedItem(Number((Page.bottomVisibleItemId().slice(4))), 'focus bottomId');

--- a/tests/ui/specs/VirtualList/VirtualList-specs.js
+++ b/tests/ui/specs/VirtualList/VirtualList-specs.js
@@ -395,7 +395,7 @@ describe('VirtualList', function () {
 			// Step 3. 1. Position the pointer on the last item in a current page.
 			bottomId = Page.bottomVisibleItemId();
 			Page.showPointerByKeycode();
-			Page.item(bottomId).moveTo({yOffset:10});	// The upper part of the item, not the center
+			Page.item(bottomId).moveTo({yOffset:10}); // The upper part of the item, not the center
 			// Verify Step 3: Spotlight displays on the item.
 			Page.delay(1000); // needed to run on mpc
 			expectFocusedItem(Number((Page.bottomVisibleItemId().slice(4))), 'focus bottomId');


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When we use latest chrome driver not 2.44, some test cases are failed due to api change.


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
1. Interact (eg. click) with "#floatLayer>div"instead of "#floatLayer"because the size is zero. 
2. Since click() and moveTo() operate based on the center coordinate, the coordinates need to be adjusted.
3. isDisplayed() returns true for expandableList items that are not visible due to parent overflow:hidden, so there is no way to check this. Because we already verify the close status so I think we can skip the verifying for item visibility.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRN-792
Jenkins pass : enact-ui-tests/1966/

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)