### PR TITLE
WRN-6746: qa-VirtualGridListNative with 'Horizontal' on displays the paging controls in the wrong direction.

### DIFF
--- a/samples/qa-a11y/src/views/Option.js
+++ b/samples/qa-a11y/src/views/Option.js
@@ -14,9 +14,9 @@ const Option = (props) => {
 	return (
 		<div>
 			<Heading showLine>Set a language direction</Heading>
-			<ToggleButton size="small" onClick={handleClick} selected={rtl}>RTL</ToggleButton>
+			<ToggleButton size="small" onToggle={handleClick} selected={rtl}>RTL</ToggleButton>
 			<Heading showLine>Set an aria debug mode</Heading>
-			<ToggleButton size="small" onClick={handleDebug} selected={isDebugMode}>Debug aria</ToggleButton>
+			<ToggleButton size="small" onToggle={handleDebug} selected={isDebugMode}>Debug aria</ToggleButton>
 		</div>
 	);
 };

--- a/samples/qa-a11y/src/views/Option.js
+++ b/samples/qa-a11y/src/views/Option.js
@@ -7,16 +7,16 @@ import ToggleButton from '@enact/moonstone/ToggleButton';
 const Option = (props) => {
 	const {handleDebug, isDebugMode} = props;
 	const {rtl, updateLocale} = useI18nContext();
-	const handleClick = useCallback(() => {
+	const handleToggle = useCallback(() => {
 		updateLocale(rtl ? 'en-US' : 'ar-SA');
 	}, [rtl, updateLocale]);
 
 	return (
 		<div>
 			<Heading showLine>Set a language direction</Heading>
-			<ToggleButton size="small" onClick={handleClick} selected={rtl}>RTL</ToggleButton>
+			<ToggleButton size="small" onToggle={handleToggle} selected={rtl}>RTL</ToggleButton>
 			<Heading showLine>Set an aria debug mode</Heading>
-			<ToggleButton size="small" onClick={handleDebug} selected={isDebugMode}>Debug aria</ToggleButton>
+			<ToggleButton size="small" onToggle={handleDebug} selected={isDebugMode}>Debug aria</ToggleButton>
 		</div>
 	);
 };

--- a/samples/qa-a11y/src/views/Option.js
+++ b/samples/qa-a11y/src/views/Option.js
@@ -14,9 +14,9 @@ const Option = (props) => {
 	return (
 		<div>
 			<Heading showLine>Set a language direction</Heading>
-			<ToggleButton size="small" onToggle={handleClick} selected={rtl}>RTL</ToggleButton>
+			<ToggleButton size="small" onClick={handleClick} selected={rtl}>RTL</ToggleButton>
 			<Heading showLine>Set an aria debug mode</Heading>
-			<ToggleButton size="small" onToggle={handleDebug} selected={isDebugMode}>Debug aria</ToggleButton>
+			<ToggleButton size="small" onClick={handleDebug} selected={isDebugMode}>Debug aria</ToggleButton>
 		</div>
 	);
 };

--- a/samples/qa-a11y/src/views/Scroller.js
+++ b/samples/qa-a11y/src/views/Scroller.js
@@ -27,14 +27,14 @@ class ScrollerView extends Component {
 				<Cell shrink>
 					<ToggleButton
 						size="small"
-						onToggle={this.onClickChangeAriaLabelButton}
+						onClick={this.onClickChangeAriaLabelButton}
 						selected={customAriaLabel}
 					>
 						Customizable aria-labels on ScrollButtons
 					</ToggleButton>
 					<ToggleButton
 						size="small"
-						onToggle={this.onClickChangeJSNativeButton}
+						onClick={this.onClickChangeJSNativeButton}
 						selected={isNative}
 					>
 						Native

--- a/samples/qa-a11y/src/views/Scroller.js
+++ b/samples/qa-a11y/src/views/Scroller.js
@@ -13,9 +13,9 @@ class ScrollerView extends Component {
 		};
 	}
 
-	onClickChangeAriaLabelButton = () => this.setState((state) => ({customAriaLabel: !state.customAriaLabel}));
+	onToggleChangeAriaLabelButton = () => this.setState((state) => ({customAriaLabel: !state.customAriaLabel}));
 
-	onClickChangeJSNativeButton = () => this.setState((state) => ({isNative: !state.isNative}));
+	onToggleChangeJSNativeButton = () => this.setState((state) => ({isNative: !state.isNative}));
 
 	render () {
 		const
@@ -27,14 +27,14 @@ class ScrollerView extends Component {
 				<Cell shrink>
 					<ToggleButton
 						size="small"
-						onClick={this.onClickChangeAriaLabelButton}
+						onToggle={this.onToggleChangeAriaLabelButton}
 						selected={customAriaLabel}
 					>
 						Customizable aria-labels on ScrollButtons
 					</ToggleButton>
 					<ToggleButton
 						size="small"
-						onClick={this.onClickChangeJSNativeButton}
+						onToggle={this.onToggleChangeJSNativeButton}
 						selected={isNative}
 					>
 						Native

--- a/samples/qa-a11y/src/views/Scroller.js
+++ b/samples/qa-a11y/src/views/Scroller.js
@@ -27,14 +27,14 @@ class ScrollerView extends Component {
 				<Cell shrink>
 					<ToggleButton
 						size="small"
-						onClick={this.onClickChangeAriaLabelButton}
+						onToggle={this.onClickChangeAriaLabelButton}
 						selected={customAriaLabel}
 					>
 						Customizable aria-labels on ScrollButtons
 					</ToggleButton>
 					<ToggleButton
 						size="small"
-						onClick={this.onClickChangeJSNativeButton}
+						onToggle={this.onClickChangeJSNativeButton}
 						selected={isNative}
 					>
 						Native

--- a/samples/qa-a11y/src/views/VirtualGridList.js
+++ b/samples/qa-a11y/src/views/VirtualGridList.js
@@ -66,21 +66,21 @@ class VirtualGridListView extends Component {
 				<Cell shrink>
 					<ToggleButton
 						size="small"
-						onToggle={this.onClickChangeAriaLabelButton}
+						onClick={this.onClickChangeAriaLabelButton}
 						selected={customAriaLabel}
 					>
 						Customizable aria-labels on ScrollButtons
 					</ToggleButton>
 					<ToggleButton
 						size="small"
-						onToggle={this.onClickChangeDirectionButton}
+						onClick={this.onClickChangeDirectionButton}
 						selected={isHorizontalList}
 					>
 						Horizontal
 					</ToggleButton>
 					<ToggleButton
 						size="small"
-						onToggle={this.onClickChangeJSNativeButton}
+						onClick={this.onClickChangeJSNativeButton}
 						selected={isNative}
 					>
 						Native

--- a/samples/qa-a11y/src/views/VirtualGridList.js
+++ b/samples/qa-a11y/src/views/VirtualGridList.js
@@ -66,21 +66,21 @@ class VirtualGridListView extends Component {
 				<Cell shrink>
 					<ToggleButton
 						size="small"
-						onClick={this.onClickChangeAriaLabelButton}
+						onToggle={this.onClickChangeAriaLabelButton}
 						selected={customAriaLabel}
 					>
 						Customizable aria-labels on ScrollButtons
 					</ToggleButton>
 					<ToggleButton
 						size="small"
-						onClick={this.onClickChangeDirectionButton}
+						onToggle={this.onClickChangeDirectionButton}
 						selected={isHorizontalList}
 					>
 						Horizontal
 					</ToggleButton>
 					<ToggleButton
 						size="small"
-						onClick={this.onClickChangeJSNativeButton}
+						onToggle={this.onClickChangeJSNativeButton}
 						selected={isNative}
 					>
 						Native

--- a/samples/qa-a11y/src/views/VirtualGridList.js
+++ b/samples/qa-a11y/src/views/VirtualGridList.js
@@ -50,11 +50,11 @@ class VirtualGridListView extends Component {
 		};
 	}
 
-	onClickChangeAriaLabelButton = () => this.setState((state) => ({customAriaLabel: !state.customAriaLabel}));
+	onToggleChangeAriaLabelButton = () => this.setState((state) => ({customAriaLabel: !state.customAriaLabel}));
 
-	onClickChangeDirectionButton = () => this.setState((state) => ({isHorizontalList: !state.isHorizontalList}));
+	onToggleChangeDirectionButton = () => this.setState((state) => ({isHorizontalList: !state.isHorizontalList}));
 
-	onClickChangeJSNativeButton = () => this.setState((state) => ({isNative: !state.isNative}));
+	onToggleChangeJSNativeButton = () => this.setState((state) => ({isNative: !state.isNative}));
 
 	render () {
 		const
@@ -66,21 +66,21 @@ class VirtualGridListView extends Component {
 				<Cell shrink>
 					<ToggleButton
 						size="small"
-						onClick={this.onClickChangeAriaLabelButton}
+						onToggle={this.onToggleChangeAriaLabelButton}
 						selected={customAriaLabel}
 					>
 						Customizable aria-labels on ScrollButtons
 					</ToggleButton>
 					<ToggleButton
 						size="small"
-						onClick={this.onClickChangeDirectionButton}
+						onToggle={this.onToggleChangeDirectionButton}
 						selected={isHorizontalList}
 					>
 						Horizontal
 					</ToggleButton>
 					<ToggleButton
 						size="small"
-						onClick={this.onClickChangeJSNativeButton}
+						onToggle={this.onToggleChangeJSNativeButton}
 						selected={isNative}
 					>
 						Native

--- a/samples/qa-a11y/src/views/VirtualList.js
+++ b/samples/qa-a11y/src/views/VirtualList.js
@@ -81,7 +81,7 @@ class VirtualListView extends Component {
 					</ToggleButton>
 					<ToggleButton
 						size="small"
-						onToggle={this.onClickChangeJSNativeButton}
+						onClick={this.onClickChangeJSNativeButton}
 						selected={isNative}
 					>
 						Native

--- a/samples/qa-a11y/src/views/VirtualList.js
+++ b/samples/qa-a11y/src/views/VirtualList.js
@@ -67,14 +67,14 @@ class VirtualListView extends Component {
 				<Cell shrink>
 					<ToggleButton
 						size="small"
-						onToggle={this.onClickChangeAriaLabelButton}
+						onClick={this.onClickChangeAriaLabelButton}
 						selected={customAriaLabel}
 					>
 						Customizable aria-labels on ScrollButtons
 					</ToggleButton>
 					<ToggleButton
 						size="small"
-						onToggle={this.onClickChangeDirectionButton}
+						onClick={this.onClickChangeDirectionButton}
 						selected={isHorizontalList}
 					>
 						Horizontal

--- a/samples/qa-a11y/src/views/VirtualList.js
+++ b/samples/qa-a11y/src/views/VirtualList.js
@@ -51,11 +51,11 @@ class VirtualListView extends Component {
 		};
 	}
 
-	onClickChangeAriaLabelButton = () => this.setState((state) => ({customAriaLabel: !state.customAriaLabel}));
+	onToggleChangeAriaLabelButton = () => this.setState((state) => ({customAriaLabel: !state.customAriaLabel}));
 
-	onClickChangeDirectionButton = () => this.setState((state) => ({isHorizontalList: !state.isHorizontalList}));
+	onToggleChangeDirectionButton = () => this.setState((state) => ({isHorizontalList: !state.isHorizontalList}));
 
-	onClickChangeJSNativeButton = () => this.setState((state) => ({isNative: !state.isNative}));
+	onToggleChangeJSNativeButton = () => this.setState((state) => ({isNative: !state.isNative}));
 
 	render () {
 		const
@@ -67,21 +67,21 @@ class VirtualListView extends Component {
 				<Cell shrink>
 					<ToggleButton
 						size="small"
-						onClick={this.onClickChangeAriaLabelButton}
+						onToggle={this.onToggleChangeAriaLabelButton}
 						selected={customAriaLabel}
 					>
 						Customizable aria-labels on ScrollButtons
 					</ToggleButton>
 					<ToggleButton
 						size="small"
-						onClick={this.onClickChangeDirectionButton}
+						onToggle={this.onToggleChangeDirectionButton}
 						selected={isHorizontalList}
 					>
 						Horizontal
 					</ToggleButton>
 					<ToggleButton
 						size="small"
-						onClick={this.onClickChangeJSNativeButton}
+						onToggle={this.onToggleChangeJSNativeButton}
 						selected={isNative}
 					>
 						Native

--- a/samples/qa-a11y/src/views/VirtualList.js
+++ b/samples/qa-a11y/src/views/VirtualList.js
@@ -67,21 +67,21 @@ class VirtualListView extends Component {
 				<Cell shrink>
 					<ToggleButton
 						size="small"
-						onClick={this.onClickChangeAriaLabelButton}
+						onToggle={this.onClickChangeAriaLabelButton}
 						selected={customAriaLabel}
 					>
 						Customizable aria-labels on ScrollButtons
 					</ToggleButton>
 					<ToggleButton
 						size="small"
-						onClick={this.onClickChangeDirectionButton}
+						onToggle={this.onClickChangeDirectionButton}
 						selected={isHorizontalList}
 					>
 						Horizontal
 					</ToggleButton>
 					<ToggleButton
 						size="small"
-						onClick={this.onClickChangeJSNativeButton}
+						onToggle={this.onClickChangeJSNativeButton}
 						selected={isNative}
 					>
 						Native

--- a/samples/qa-scroller/src/components/LocaleSwitch/LocaleSwitch.js
+++ b/samples/qa-scroller/src/components/LocaleSwitch/LocaleSwitch.js
@@ -9,7 +9,7 @@ const LocaleSwitch = (props) => {
 	}, [rtl, updateLocale]);
 
 	return (
-		<ToggleButton onClick={onClick} {...props}>RTL</ToggleButton>
+		<ToggleButton onToggle={onClick} {...props}>RTL</ToggleButton>
 	);
 };
 

--- a/samples/qa-scroller/src/components/LocaleSwitch/LocaleSwitch.js
+++ b/samples/qa-scroller/src/components/LocaleSwitch/LocaleSwitch.js
@@ -4,12 +4,12 @@ import ToggleButton from '@enact/moonstone/ToggleButton';
 
 const LocaleSwitch = (props) => {
 	const {rtl, updateLocale} = useI18nContext();
-	const onClick = useCallback(() => {
+	const onToggle = useCallback(() => {
 		updateLocale(!rtl ? 'ar-SA' : 'en-US');
 	}, [rtl, updateLocale]);
 
 	return (
-		<ToggleButton onClick={onClick} {...props}>RTL</ToggleButton>
+		<ToggleButton onToggle={onToggle} {...props}>RTL</ToggleButton>
 	);
 };
 

--- a/samples/qa-scroller/src/components/LocaleSwitch/LocaleSwitch.js
+++ b/samples/qa-scroller/src/components/LocaleSwitch/LocaleSwitch.js
@@ -9,7 +9,7 @@ const LocaleSwitch = (props) => {
 	}, [rtl, updateLocale]);
 
 	return (
-		<ToggleButton onToggle={onClick} {...props}>RTL</ToggleButton>
+		<ToggleButton onClick={onClick} {...props}>RTL</ToggleButton>
 	);
 };
 

--- a/samples/qa-scroller/src/components/PanelHeader/PanelHeader.js
+++ b/samples/qa-scroller/src/components/PanelHeader/PanelHeader.js
@@ -27,7 +27,7 @@ class PanelHeader extends Component {
 				<div style={{direction: 'ltr'}}>
 					height:<Input size="small" onChange={handleHeight} style={inputWidth} type="number" value={height} />
 					width:<Input size="small" onChange={handleWidth} style={inputWidth} type="number" value={width} />
-					<ToggleButton size="small" onClick={handleFocusableScrollbar}>Focusable Scrollbar</ToggleButton>
+					<ToggleButton size="small" onToggle={handleFocusableScrollbar}>Focusable Scrollbar</ToggleButton>
 					<LocaleSwitch size="small" />
 					<Heading showLine />
 				</div>

--- a/samples/qa-scroller/src/components/PanelHeader/PanelHeader.js
+++ b/samples/qa-scroller/src/components/PanelHeader/PanelHeader.js
@@ -27,7 +27,7 @@ class PanelHeader extends Component {
 				<div style={{direction: 'ltr'}}>
 					height:<Input size="small" onChange={handleHeight} style={inputWidth} type="number" value={height} />
 					width:<Input size="small" onChange={handleWidth} style={inputWidth} type="number" value={width} />
-					<ToggleButton size="small" onToggle={handleFocusableScrollbar}>Focusable Scrollbar</ToggleButton>
+					<ToggleButton size="small" onClick={handleFocusableScrollbar}>Focusable Scrollbar</ToggleButton>
 					<LocaleSwitch size="small" />
 					<Heading showLine />
 				</div>

--- a/samples/qa-scroller/src/views/MainView.module.less
+++ b/samples/qa-scroller/src/views/MainView.module.less
@@ -16,7 +16,6 @@ body {
 	display: flex;
 	padding-top: 12px;
 	box-sizing: border-box;
-	border: solid gray 10px;
 	width: 100%;
 	height: 100%;
 }

--- a/samples/qa-scroller/src/views/MainView.module.less
+++ b/samples/qa-scroller/src/views/MainView.module.less
@@ -16,7 +16,7 @@ body {
 	display: flex;
 	padding-top: 12px;
 	box-sizing: border-box;
-	border: solid glay 10px;
+	border: solid gray 10px;
 	width: 100%;
 	height: 100%;
 }

--- a/samples/qa-scrollernative/src/components/LocaleSwitch/LocaleSwitch.js
+++ b/samples/qa-scrollernative/src/components/LocaleSwitch/LocaleSwitch.js
@@ -9,7 +9,7 @@ const LocaleSwitch = (props) => {
 	}, [rtl, updateLocale]);
 
 	return (
-		<ToggleButton onClick={onClick} {...props}>RTL</ToggleButton>
+		<ToggleButton onToggle={onClick} {...props}>RTL</ToggleButton>
 	);
 };
 

--- a/samples/qa-scrollernative/src/components/LocaleSwitch/LocaleSwitch.js
+++ b/samples/qa-scrollernative/src/components/LocaleSwitch/LocaleSwitch.js
@@ -4,12 +4,12 @@ import ToggleButton from '@enact/moonstone/ToggleButton';
 
 const LocaleSwitch = (props) => {
 	const {rtl, updateLocale} = useI18nContext();
-	const onClick = useCallback(() => {
+	const onToggle = useCallback(() => {
 		updateLocale(!rtl ? 'ar-SA' : 'en-US');
 	}, [rtl, updateLocale]);
 
 	return (
-		<ToggleButton onClick={onClick} {...props}>RTL</ToggleButton>
+		<ToggleButton onToggle={onToggle} {...props}>RTL</ToggleButton>
 	);
 };
 

--- a/samples/qa-scrollernative/src/components/LocaleSwitch/LocaleSwitch.js
+++ b/samples/qa-scrollernative/src/components/LocaleSwitch/LocaleSwitch.js
@@ -9,7 +9,7 @@ const LocaleSwitch = (props) => {
 	}, [rtl, updateLocale]);
 
 	return (
-		<ToggleButton onToggle={onClick} {...props}>RTL</ToggleButton>
+		<ToggleButton onClick={onClick} {...props}>RTL</ToggleButton>
 	);
 };
 

--- a/samples/qa-scrollernative/src/components/PanelHeader/PanelHeader.js
+++ b/samples/qa-scrollernative/src/components/PanelHeader/PanelHeader.js
@@ -27,7 +27,7 @@ class PanelHeader extends Component {
 				<div style={{direction: 'ltr'}}>
 					height:<Input size="small" onChange={handleHeight} style={inputWidth} type="number" value={height} />
 					width:<Input size="small" onChange={handleWidth} style={inputWidth} type="number" value={width} />
-					<ToggleButton size="small" onClick={handleFocusableScrollbar}>Focusable Scrollbar</ToggleButton>
+					<ToggleButton size="small" onToggle={handleFocusableScrollbar}>Focusable Scrollbar</ToggleButton>
 					<LocaleSwitch size="small" />
 					<Heading showLine />
 				</div>

--- a/samples/qa-scrollernative/src/components/PanelHeader/PanelHeader.js
+++ b/samples/qa-scrollernative/src/components/PanelHeader/PanelHeader.js
@@ -27,7 +27,7 @@ class PanelHeader extends Component {
 				<div style={{direction: 'ltr'}}>
 					height:<Input size="small" onChange={handleHeight} style={inputWidth} type="number" value={height} />
 					width:<Input size="small" onChange={handleWidth} style={inputWidth} type="number" value={width} />
-					<ToggleButton size="small" onToggle={handleFocusableScrollbar}>Focusable Scrollbar</ToggleButton>
+					<ToggleButton size="small" onClick={handleFocusableScrollbar}>Focusable Scrollbar</ToggleButton>
 					<LocaleSwitch size="small" />
 					<Heading showLine />
 				</div>

--- a/samples/qa-scrollernative/src/views/MainView.module.less
+++ b/samples/qa-scrollernative/src/views/MainView.module.less
@@ -16,7 +16,6 @@ body {
 	display: flex;
 	padding-top: 12px;
 	box-sizing: border-box;
-	border: solid gray 10px;
 	width: 100%;
 	height: 80%;
 }

--- a/samples/qa-scrollernative/src/views/MainView.module.less
+++ b/samples/qa-scrollernative/src/views/MainView.module.less
@@ -16,7 +16,7 @@ body {
 	display: flex;
 	padding-top: 12px;
 	box-sizing: border-box;
-	border: solid glay 10px;
+	border: solid gray 10px;
 	width: 100%;
 	height: 80%;
 }

--- a/samples/qa-virtualgridlist/src/components/LocaleSwitch/LocaleSwitch.js
+++ b/samples/qa-virtualgridlist/src/components/LocaleSwitch/LocaleSwitch.js
@@ -9,7 +9,7 @@ const LocaleSwitch = (props) => {
 	}, [rtl, updateLocale]);
 
 	return (
-		<ToggleButton onClick={onClick} {...props}>RTL</ToggleButton>
+		<ToggleButton onToggle={onClick} {...props}>RTL</ToggleButton>
 	);
 };
 

--- a/samples/qa-virtualgridlist/src/components/LocaleSwitch/LocaleSwitch.js
+++ b/samples/qa-virtualgridlist/src/components/LocaleSwitch/LocaleSwitch.js
@@ -4,12 +4,12 @@ import ToggleButton from '@enact/moonstone/ToggleButton';
 
 const LocaleSwitch = (props) => {
 	const {rtl, updateLocale} = useI18nContext();
-	const onClick = useCallback(() => {
+	const onToggle = useCallback(() => {
 		updateLocale(!rtl ? 'ar-SA' : 'en-US');
 	}, [rtl, updateLocale]);
 
 	return (
-		<ToggleButton onToggle={onClick} {...props}>RTL</ToggleButton>
+		<ToggleButton onToggle={onToggle} {...props}>RTL</ToggleButton>
 	);
 };
 

--- a/samples/qa-virtualgridlist/src/components/PanelHeader/PanelHeader.js
+++ b/samples/qa-virtualgridlist/src/components/PanelHeader/PanelHeader.js
@@ -100,12 +100,12 @@ const PanelHeader = kind({
 		},
 		changeDirectionButton: ({onChangeDirection, showOverlay}) => {
 			if (!showOverlay) {
-				return (<ToggleButton size="small" minWidth onClick={onChangeDirection}>Horizontal</ToggleButton>);
+				return (<ToggleButton size="small" minWidth onToggle={onChangeDirection}>Horizontal</ToggleButton>);
 			}
 		},
 		changeFocusableScrollbarButton: ({onChangeFocusableScrollbar, showOverlay}) => {
 			if (!showOverlay) {
-				return (<ToggleButton size="small" minWidth onClick={onChangeFocusableScrollbar}>Focusable Scrollbar</ToggleButton>);
+				return (<ToggleButton size="small" minWidth onToggle={onChangeFocusableScrollbar}>Focusable Scrollbar</ToggleButton>);
 			}
 		},
 		changeListProps: ({changeMinHeight, changeMinWidth, changeSpacing, data, setData, showOverlay}) => {

--- a/samples/qa-virtualgridlist/src/views/MainView.module.less
+++ b/samples/qa-virtualgridlist/src/views/MainView.module.less
@@ -16,7 +16,6 @@ body {
 	display: flex;
 	padding-top: 12px;
 	box-sizing: border-box;
-	border: solid gray 10px;
 	width: 100%;
 	height: 100%;
 }

--- a/samples/qa-virtualgridlist/src/views/MainView.module.less
+++ b/samples/qa-virtualgridlist/src/views/MainView.module.less
@@ -16,7 +16,7 @@ body {
 	display: flex;
 	padding-top: 12px;
 	box-sizing: border-box;
-	border: solid glay 10px;
+	border: solid gray 10px;
 	width: 100%;
 	height: 100%;
 }

--- a/samples/qa-virtualgridlistnative/src/components/LocaleSwitch/LocaleSwitch.js
+++ b/samples/qa-virtualgridlistnative/src/components/LocaleSwitch/LocaleSwitch.js
@@ -9,7 +9,7 @@ const LocaleSwitch = (props) => {
 	}, [rtl, updateLocale]);
 
 	return (
-		<ToggleButton onClick={onClick} {...props}>RTL</ToggleButton>
+		<ToggleButton onToggle={onClick} {...props}>RTL</ToggleButton>
 	);
 };
 

--- a/samples/qa-virtualgridlistnative/src/components/LocaleSwitch/LocaleSwitch.js
+++ b/samples/qa-virtualgridlistnative/src/components/LocaleSwitch/LocaleSwitch.js
@@ -4,12 +4,12 @@ import ToggleButton from '@enact/moonstone/ToggleButton';
 
 const LocaleSwitch = (props) => {
 	const {rtl, updateLocale} = useI18nContext();
-	const onClick = useCallback(() => {
+	const onToggle = useCallback(() => {
 		updateLocale(!rtl ? 'ar-SA' : 'en-US');
 	}, [rtl, updateLocale]);
 
 	return (
-		<ToggleButton onToggle={onClick} {...props}>RTL</ToggleButton>
+		<ToggleButton onToggle={onToggle} {...props}>RTL</ToggleButton>
 	);
 };
 

--- a/samples/qa-virtualgridlistnative/src/components/PanelHeader/PanelHeader.js
+++ b/samples/qa-virtualgridlistnative/src/components/PanelHeader/PanelHeader.js
@@ -100,12 +100,12 @@ const PanelHeader = kind({
 		},
 		changeDirectionButton: ({onChangeDirection, showOverlay}) => {
 			if (!showOverlay) {
-				return (<ToggleButton size="small" minWidth onClick={onChangeDirection}>Horizontal</ToggleButton>);
+				return (<ToggleButton size="small" minWidth onToggle={onChangeDirection}>Horizontal</ToggleButton>);
 			}
 		},
 		changeFocusableScrollbarButton: ({onChangeFocusableScrollbar, showOverlay}) => {
 			if (!showOverlay) {
-				return (<ToggleButton size="small" minWidth onClick={onChangeFocusableScrollbar}>Focusable Scrollbar</ToggleButton>);
+				return (<ToggleButton size="small" minWidth onToggle={onChangeFocusableScrollbar}>Focusable Scrollbar</ToggleButton>);
 			}
 		},
 		changeListProps: ({changeMinHeight, changeMinWidth, changeSpacing, data, setData, showOverlay}) => {

--- a/samples/qa-virtualgridlistnative/src/views/MainView.js
+++ b/samples/qa-virtualgridlistnative/src/views/MainView.js
@@ -9,12 +9,12 @@ const MainView = () => {
 	const [focusableScrollbar, setFocusableScrollbar] = useState(false);
 	const [horizontal, setHorizontal] = useState(false);
 
-	function onChangeFocusableScrollbar () {
-		setFocusableScrollbar(!focusableScrollbar);
-	}
-
 	function onChangeDirection () {
 		setHorizontal(!horizontal);
+	}
+
+	function onChangeFocusableScrollbar () {
+		setFocusableScrollbar(!focusableScrollbar);
 	}
 
 	return (

--- a/samples/qa-virtualgridlistnative/src/views/MainView.js
+++ b/samples/qa-virtualgridlistnative/src/views/MainView.js
@@ -20,16 +20,16 @@ const MainView = () => {
 	return (
 		<div className={css.mainView} style={{flexDirection: horizontal ? 'row' : 'column'}}>
 			<PanelHeader
-				title="VirtualGridList Native"
-				type="compact"
 				onChangeDirection={onChangeDirection}
 				onChangeFocusableScrollbar={onChangeFocusableScrollbar}
+				title="VirtualGridList Native"
+				type="compact"
 			/>
 			<div className={css.content}>
 				<ImageList
 					className={css.list}
-					focusableScrollbar={focusableScrollbar}
 					direction={horizontal ? 'horizontal' : 'vertical'}
+					focusableScrollbar={focusableScrollbar}
 				/>
 			</div>
 		</div>

--- a/samples/qa-virtualgridlistnative/src/views/MainView.js
+++ b/samples/qa-virtualgridlistnative/src/views/MainView.js
@@ -1,55 +1,41 @@
-import {Component} from 'react';
+import {useEffect, useState} from 'react';
 
 import ImageList from '../components/ImageList';
 import PanelHeader from '../components/PanelHeader';
 
 import css from './MainView.module.less';
 
-class MainView extends Component {
-	constructor (props) {
-		super(props);
-		this.state = {
-			focusableScrollbar: false,
-			horizontal: false
-		};
+const MainView = () => {
+	const [focusableScrollbar, setFocusableScrollbar] = useState(false);
+	const [horizontal, setHorizontal] = useState(false);
+
+	useEffect(() => {
+	}, [focusableScrollbar, horizontal])
+
+	function onChangeFocusableScrollbar() {
+		setFocusableScrollbar(!focusableScrollbar);
 	}
 
-	componentDidUpdate () {
-		this.scrollTo({index: 0, animate: false, focus: true});
+	function onChangeDirection() {
+		setHorizontal(!horizontal);
 	}
 
-	onChangeFocusableScrollbar = () => {
-		this.setState((state) => ({focusableScrollbar: !state.focusableScrollbar}));
-	};
-
-	onChangeDirection = () => {
-		this.setState((state) => ({horizontal: !state.horizontal}));
-	};
-
-	getScrollTo = (scrollTo) => {
-		this.scrollTo = scrollTo;
-	};
-
-	render = () => {
-		return (
-			<div className={css.mainView}>
-				<PanelHeader
-					title="VirtualGridList Native"
-					type="compact"
-					onChangeDirection={this.onChangeDirection}
-					onChangeFocusableScrollbar={this.onChangeFocusableScrollbar}
+	return (
+		<div className={css.mainView} style={{flexDirection: horizontal? 'row' : 'column'}}>
+			<PanelHeader
+				title="VirtualGridList Native"
+				type="compact"
+				onChangeDirection={onChangeDirection}
+				onChangeFocusableScrollbar={onChangeFocusableScrollbar}
+			/>
+			<div className={css.content}>
+				<ImageList
+					className={css.list}
+					focusableScrollbar={focusableScrollbar}
+					direction={horizontal ? 'horizontal' : 'vertical'}
 				/>
-				<div className={css.content}>
-					<ImageList
-						cbScrollTo={this.getScrollTo}
-						className={css.list}
-						focusableScrollbar={this.state.focusableScrollbar}
-						direction={this.state.horizontal ? 'horizontal' : 'vertical'}
-					/>
-				</div>
 			</div>
-		);
-	};
+		</div>
+	);
 }
-
 export default MainView;

--- a/samples/qa-virtualgridlistnative/src/views/MainView.js
+++ b/samples/qa-virtualgridlistnative/src/views/MainView.js
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react';
+import {useState} from 'react';
 
 import ImageList from '../components/ImageList';
 import PanelHeader from '../components/PanelHeader';
@@ -9,19 +9,16 @@ const MainView = () => {
 	const [focusableScrollbar, setFocusableScrollbar] = useState(false);
 	const [horizontal, setHorizontal] = useState(false);
 
-	useEffect(() => {
-	}, [focusableScrollbar, horizontal])
-
-	function onChangeFocusableScrollbar() {
+	function onChangeFocusableScrollbar () {
 		setFocusableScrollbar(!focusableScrollbar);
 	}
 
-	function onChangeDirection() {
+	function onChangeDirection () {
 		setHorizontal(!horizontal);
 	}
 
 	return (
-		<div className={css.mainView} style={{flexDirection: horizontal? 'row' : 'column'}}>
+		<div className={css.mainView} style={{flexDirection: horizontal ? 'row' : 'column'}}>
 			<PanelHeader
 				title="VirtualGridList Native"
 				type="compact"
@@ -37,5 +34,5 @@ const MainView = () => {
 			</div>
 		</div>
 	);
-}
+};
 export default MainView;

--- a/samples/qa-virtualgridlistnative/src/views/MainView.js
+++ b/samples/qa-virtualgridlistnative/src/views/MainView.js
@@ -18,7 +18,7 @@ const MainView = () => {
 	}
 
 	return (
-		<div className={css.mainView} style={{flexDirection: horizontal ? 'row' : 'column'}}>
+		<div className={css.mainView}>
 			<PanelHeader
 				onChangeDirection={onChangeDirection}
 				onChangeFocusableScrollbar={onChangeFocusableScrollbar}

--- a/samples/qa-virtualgridlistnative/src/views/MainView.module.less
+++ b/samples/qa-virtualgridlistnative/src/views/MainView.module.less
@@ -16,7 +16,6 @@ body {
 	display: flex;
 	padding-top: 12px;
 	box-sizing: border-box;
-	border: solid gray 10px;
 	width: 100%;
 	height: 75%;
 }

--- a/samples/qa-virtualgridlistnative/src/views/MainView.module.less
+++ b/samples/qa-virtualgridlistnative/src/views/MainView.module.less
@@ -8,6 +8,7 @@ body {
 
 .mainView {
 	display: flex;
+	flex-direction: column;
 	height: 100%;
 }
 

--- a/samples/qa-virtualgridlistnative/src/views/MainView.module.less
+++ b/samples/qa-virtualgridlistnative/src/views/MainView.module.less
@@ -8,7 +8,6 @@ body {
 
 .mainView {
 	display: flex;
-	flex-direction: column;
 	height: 100%;
 }
 
@@ -16,7 +15,7 @@ body {
 	display: flex;
 	padding-top: 12px;
 	box-sizing: border-box;
-	border: solid glay 10px;
+	border: solid gray 10px;
 	width: 100%;
 	height: 75%;
 }

--- a/samples/qa-virtuallist/src/components/LocaleSwitch/LocaleSwitch.js
+++ b/samples/qa-virtuallist/src/components/LocaleSwitch/LocaleSwitch.js
@@ -9,7 +9,7 @@ const LocaleSwitch = (props) => {
 	}, [rtl, updateLocale]);
 
 	return (
-		<ToggleButton onClick={onClick} {...props}>RTL</ToggleButton>
+		<ToggleButton onToggle={onClick} {...props}>RTL</ToggleButton>
 	);
 };
 

--- a/samples/qa-virtuallist/src/components/LocaleSwitch/LocaleSwitch.js
+++ b/samples/qa-virtuallist/src/components/LocaleSwitch/LocaleSwitch.js
@@ -4,12 +4,12 @@ import ToggleButton from '@enact/moonstone/ToggleButton';
 
 const LocaleSwitch = (props) => {
 	const {rtl, updateLocale} = useI18nContext();
-	const onClick = useCallback(() => {
+	const onToggle = useCallback(() => {
 		updateLocale(!rtl ? 'ar-SA' : 'en-US');
 	}, [rtl, updateLocale]);
 
 	return (
-		<ToggleButton onToggle={onClick} {...props}>RTL</ToggleButton>
+		<ToggleButton onToggle={onToggle} {...props}>RTL</ToggleButton>
 	);
 };
 

--- a/samples/qa-virtuallist/src/views/MainPanel.js
+++ b/samples/qa-virtuallist/src/views/MainPanel.js
@@ -85,8 +85,8 @@ const MainPanel = class extends Component {
 							value={this.state.value}
 						/>
 						<Button size="small" onClick={this.onChangeDataSize}>Set DataSize</Button>
-						<ToggleButton size="small" onClick={this.onToggleDisabled}>Disabled Items</ToggleButton>
-						<ToggleButton size="small" onClick={this.onToggleChildProps}>Child Props</ToggleButton>
+						<ToggleButton size="small" onToggle={this.onToggleDisabled}>Disabled Items</ToggleButton>
+						<ToggleButton size="small" onToggle={this.onToggleChildProps}>Child Props</ToggleButton>
 						<LocaleSwitch size="small" />
 						<Heading showLine />
 					</div>

--- a/samples/qa-virtuallistnative/src/components/LocaleSwitch/LocaleSwitch.js
+++ b/samples/qa-virtuallistnative/src/components/LocaleSwitch/LocaleSwitch.js
@@ -9,7 +9,7 @@ const LocaleSwitch = (props) => {
 	}, [rtl, updateLocale]);
 
 	return (
-		<ToggleButton onClick={onClick} {...props}>RTL</ToggleButton>
+		<ToggleButton onToggle={onClick} {...props}>RTL</ToggleButton>
 	);
 };
 

--- a/samples/qa-virtuallistnative/src/components/LocaleSwitch/LocaleSwitch.js
+++ b/samples/qa-virtuallistnative/src/components/LocaleSwitch/LocaleSwitch.js
@@ -4,12 +4,12 @@ import ToggleButton from '@enact/moonstone/ToggleButton';
 
 const LocaleSwitch = (props) => {
 	const {rtl, updateLocale} = useI18nContext();
-	const onClick = useCallback(() => {
+	const onToggle = useCallback(() => {
 		updateLocale(!rtl ? 'ar-SA' : 'en-US');
 	}, [rtl, updateLocale]);
 
 	return (
-		<ToggleButton onToggle={onClick} {...props}>RTL</ToggleButton>
+		<ToggleButton onToggle={onToggle} {...props}>RTL</ToggleButton>
 	);
 };
 

--- a/samples/qa-virtuallistnative/src/views/MainPanel.js
+++ b/samples/qa-virtuallistnative/src/views/MainPanel.js
@@ -85,8 +85,8 @@ const MainPanel = class extends Component {
 							value={this.state.value}
 						/>
 						<Button size="small" onClick={this.onChangeDataSize}>Set DataSize</Button>
-						<ToggleButton size="small" onClick={this.onToggleDisabled}>Disabled Items</ToggleButton>
-						<ToggleButton size="small" onClick={this.onToggleChildProps}>Child Props</ToggleButton>
+						<ToggleButton size="small" onToggle={this.onToggleDisabled}>Disabled Items</ToggleButton>
+						<ToggleButton size="small" onToggle={this.onToggleChildProps}>Child Props</ToggleButton>
 						<LocaleSwitch size="small" />
 						<Heading showLine />
 					</div>

--- a/samples/sampler/stories/qa/ToggleButton.js
+++ b/samples/sampler/stories/qa/ToggleButton.js
@@ -21,7 +21,7 @@ storiesOf('ToggleButton', module)
 		'with long text',
 		() => (
 			<ToggleButton
-				onToggle={action('onClick')}
+				onToggle={action('onToggle')}
 				backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity, Config)}
 				disabled={boolean('disabled', Config)}
 				size={select('size', ['small', 'large'], Config)}
@@ -34,7 +34,7 @@ storiesOf('ToggleButton', module)
 		'with tall characters',
 		() => (
 			<ToggleButton
-				onToggle={action('onClick')}
+				onToggle={action('onToggle')}
 				backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity, Config)}
 				disabled={boolean('disabled', Config)}
 				size={select('size', ['small', 'large'], Config)}

--- a/samples/sampler/stories/qa/ToggleButton.js
+++ b/samples/sampler/stories/qa/ToggleButton.js
@@ -22,6 +22,7 @@ storiesOf('ToggleButton', module)
 		() => (
 			<ToggleButton
 				onClick={action('onClick')}
+				onToggle={action('onToggle')}
 				backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity, Config)}
 				disabled={boolean('disabled', Config)}
 				size={select('size', ['small', 'large'], Config)}
@@ -35,6 +36,7 @@ storiesOf('ToggleButton', module)
 		() => (
 			<ToggleButton
 				onClick={action('onClick')}
+				onToggle={action('onToggle')}
 				backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity, Config)}
 				disabled={boolean('disabled', Config)}
 				size={select('size', ['small', 'large'], Config)}

--- a/samples/sampler/stories/qa/ToggleButton.js
+++ b/samples/sampler/stories/qa/ToggleButton.js
@@ -21,7 +21,7 @@ storiesOf('ToggleButton', module)
 		'with long text',
 		() => (
 			<ToggleButton
-				onToggle={action('onToggle')}
+				onClick={action('onClick')}
 				backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity, Config)}
 				disabled={boolean('disabled', Config)}
 				size={select('size', ['small', 'large'], Config)}
@@ -34,7 +34,7 @@ storiesOf('ToggleButton', module)
 		'with tall characters',
 		() => (
 			<ToggleButton
-				onToggle={action('onToggle')}
+				onClick={action('onClick')}
 				backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity, Config)}
 				disabled={boolean('disabled', Config)}
 				size={select('size', ['small', 'large'], Config)}

--- a/samples/sampler/stories/qa/ToggleButton.js
+++ b/samples/sampler/stories/qa/ToggleButton.js
@@ -21,7 +21,7 @@ storiesOf('ToggleButton', module)
 		'with long text',
 		() => (
 			<ToggleButton
-				onClick={action('onClick')}
+				onToggle={action('onClick')}
 				backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity, Config)}
 				disabled={boolean('disabled', Config)}
 				size={select('size', ['small', 'large'], Config)}
@@ -34,7 +34,7 @@ storiesOf('ToggleButton', module)
 		'with tall characters',
 		() => (
 			<ToggleButton
-				onClick={action('onClick')}
+				onToggle={action('onClick')}
 				backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity, Config)}
 				disabled={boolean('disabled', Config)}
 				size={select('size', ['small', 'large'], Config)}


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
qa-VirtualGridListNative with 'Horizontal' on displays the Paging controls in the opposite direction

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The problem was not caused by anything VirtualGridListNative related. The ToggleButton, when you only press on it's edge (like it was described), does activate onClick, so the prop changes (thus the change in direction) but does not activate onToggle, so the button stays the same. I replaced onClick with onToggle everywhere the ToggleButton was used to avoid this problem in other samples.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
In the future when ToggleButton is used call onToggle rather than onClick.

### Links
[//]: # (Related issues, references)
WRN-6746

### Comments
