### PR TITLE
WRN-6753: Fixed Cross-Platform Enact iOS: VideoPlayer - A video does not start to play

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Added
 
-- `moonstone/Video` prop `playsInline` to control whether video is played inline
+- `moonstone/Video` attribute `playsInline` to allow playing videos on iOS devices without requiring fullscreen mode
 
 ## [4.0.3] - 2021-09-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Added
+
+- `moonstone/Video` prop `playsInline` to control whether video is played inline
+
 ## [4.0.3] - 2021-09-29
 
 ### Fixed

--- a/VideoPlayer/Video.js
+++ b/VideoPlayer/Video.js
@@ -69,18 +69,6 @@ const VideoBase = class extends Component {
 		mediaComponent: EnactPropTypes.renderableOverride,
 
 		/**
-		 * A Boolean attribute indicating that the video is to be played "inline",
-		 * that is within the element's playback area.
-		 *
-		 * Note that the absence of this attribute does not imply that the video will always be played in fullscreen.
-		 *
-		 * @type {Boolean}
-		 * @public
-		 * @default true
-		 */
-		playsInline: PropTypes.bool,
-
-		/**
 		 * The video source to be preloaded. Expects a `<source>` node.
 		 *
 		 * @type {Node}

--- a/VideoPlayer/Video.js
+++ b/VideoPlayer/Video.js
@@ -69,12 +69,24 @@ const VideoBase = class extends Component {
 		mediaComponent: EnactPropTypes.renderableOverride,
 
 		/**
+		 * A Boolean attribute indicating that the video is to be played "inline",
+		 * that is within the element's playback area.
+		 *
+		 * Note that the absence of this attribute does not imply that the video will always be played in fullscreen.
+		 *
+		 * @type {Boolean}
+		 * @public
+		 * @default true
+		 */
+		playsInline: PropTypes.bool,
+
+		/**
 		 * The video source to be preloaded. Expects a `<source>` node.
 		 *
 		 * @type {Node}
 		 * @public
 		 */
-		preloadSource:  PropTypes.node,
+		preloadSource: PropTypes.node,
 
 		/**
 		 * Called with a reference to the active [Media]{@link ui/Media.Media} component.
@@ -218,6 +230,7 @@ const VideoBase = class extends Component {
 						controls={false}
 						key={sourceKey}
 						mediaComponent={mediaComponent}
+						playsInline
 						preload="none"
 						ref={this.setVideoRef}
 						source={isValidElement(source) ? source : (
@@ -233,6 +246,7 @@ const VideoBase = class extends Component {
 						key={preloadKey}
 						mediaComponent={mediaComponent}
 						onLoadStart={this.handlePreloadLoadStart}
+						playsInline
 						preload="none"
 						ref={this.setPreloadRef}
 						source={isValidElement(preloadSource) ? preloadSource : (

--- a/samples/sampler/stories/default/VideoPlayer.js
+++ b/samples/sampler/stories/default/VideoPlayer.js
@@ -124,7 +124,6 @@ storiesOf('Moonstone', module)
 						noMiniFeedback={boolean('noMiniFeedback', Config)}
 						noSlider={boolean('noSlider', Config)}
 						pauseAtEnd={boolean('pauseAtEnd', Config)}
-						playsInline={boolean('playsInline', Config, true)}
 						poster={poster}
 						seekDisabled={boolean('seekDisabled', Config)}
 						spotlightDisabled={boolean('spotlightDisabled', Config)}

--- a/samples/sampler/stories/default/VideoPlayer.js
+++ b/samples/sampler/stories/default/VideoPlayer.js
@@ -124,6 +124,7 @@ storiesOf('Moonstone', module)
 						noMiniFeedback={boolean('noMiniFeedback', Config)}
 						noSlider={boolean('noSlider', Config)}
 						pauseAtEnd={boolean('pauseAtEnd', Config)}
+						playsInline={boolean('playsInline', Config, true)}
 						poster={poster}
 						seekDisabled={boolean('seekDisabled', Config)}
 						spotlightDisabled={boolean('spotlightDisabled', Config)}


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Stanca Pop stanca.pop@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Added `playsInline` attribute to Video component. If set to true, the video starts playing on mobile iOS even if it is not entirely visible or on fullscreen.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRN-6753

### Comments
