### PR TITLE
WRN-6758: Cross-Platform Enact Android - RangePicker: +/= do not show on number vkb

### DIFF
--- a/Input/Input.js
+++ b/Input/Input.js
@@ -242,6 +242,16 @@ const InputBase = kind({
 		},
 		className: ({invalid, size, styler}) => styler.append({invalid}, size),
 		dir: ({value, placeholder}) => isRtlText(value || placeholder) ? 'rtl' : 'ltr',
+		inputMode: ({type}) => {
+			// eslint-disable-next-line
+			const samsung = navigator.userAgent.includes('SM-');
+			return type === 'number' && samsung ? 'numeric' : '';
+		},
+		inputType: ({type}) => {
+			// eslint-disable-next-line
+			const samsung = navigator.userAgent.includes('SM-');
+			return type === 'number' && samsung ? 'text' : type;
+		},
 		invalidTooltip: ({css, invalid, invalidMessage = $L('Please enter a valid value.'), rtl}) => {
 			if (invalid && invalidMessage) {
 				const direction = rtl ? 'left' : 'right';
@@ -256,13 +266,14 @@ const InputBase = kind({
 		value: ({value}) => typeof value === 'number' ? value : (value || '')
 	},
 
-	render: ({css, dir, disabled, iconAfter, iconBefore, invalidTooltip, onChange, placeholder, size, type, value, ...rest}) => {
+	render: ({css, dir, disabled, iconAfter, iconBefore, inputMode, inputType, invalidTooltip, onChange, placeholder, size, value, ...rest}) => {
 		const inputProps = extractInputProps(rest);
 		const voiceProps = extractVoiceProps(rest);
 		delete rest.dismissOnEnter;
 		delete rest.invalid;
 		delete rest.invalidMessage;
 		delete rest.rtl;
+		delete rest.type;
 
 		return (
 			<div {...rest} disabled={disabled}>
@@ -275,10 +286,11 @@ const InputBase = kind({
 					className={css.input}
 					dir={dir}
 					disabled={disabled}
+					inputMode={inputMode}
 					onChange={onChange}
 					placeholder={placeholder}
 					tabIndex={-1}
-					type={type}
+					type={inputType}
 					value={value}
 				/>
 				<InputDecoratorIcon position="after" size={size}>{iconAfter}</InputDecoratorIcon>


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
On VKB, +/= are missing.
This problem only appears on Samsung devices because they use their own numeric keyboard. We can't solve it from the
knobs because we need to modify the storybook's code. I checked and the problem was reproduced on our Input component so I resolved it there.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added a check to the input and in case the device is a Samsung one changes the input type=number, so it opens a different type of VKB(added a new prop called inputMode so we have '-' at least).

### Before
![Numeric Keyboard Before](https://user-images.githubusercontent.com/84004128/140932619-3ec0a9cc-bd99-4bd2-b3da-d26030b0495c.jpg)
### After
![Numeric Keyboard After](https://user-images.githubusercontent.com/84004128/140932625-3c5c8f83-a5b0-4c0b-b6a1-aefd6057e4bc.jpg)
### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-6758

### Comments
