### PR TITLE
WRN-6752: Signage + TV - MediaOverlay: source Big Buck Bunny does not show

### DIFF
--- a/samples/sampler/stories/default/MediaOverlay.js
+++ b/samples/sampler/stories/default/MediaOverlay.js
@@ -13,7 +13,7 @@ const prop = {
 	],
 	videos: {
 		'Sintel': 'http://media.w3.org/2010/05/sintel/trailer.mp4',
-		'Big Buck Bunny': 'http://download.blender.org/peach/bigbuckbunny_movies/big_buck_bunny_480p_h264.mov',
+		'Big Buck Bunny': 'http://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4',
 		'VideoTest': 'http://media.w3.org/2010/05/video/movie_300.mp4',
 		// Purposefully not a video to demonstrate source error state
 		'Bad Video Source': 'https://github.com/mderrick/react-html5video'


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fixed Big Buck Bunny video source

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRN-6752

### Comments

Enact-DCO-1.0-Signed-off-by: Paul Beldean paul.beldean@lgepartner.com