### PR TITLE
WRN-6762: Cross-Platform Enact Android: qa-scrollerNative/qa-VirtualGridListNative - when changing 'width', 'dataSize', VKB flashes and goes away

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Scrollable` handleResizeWindow method to not blur the focused item if its type is input
 - `moonstone/ScrollableNative` handleResizeWindow method to not blur the focused item if its type is input
 
-
 ## [4.0.3] - 2021-09-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `moonstone/Scrollable` handleResizeWindow method to not blur the focused item if its type is input
+- `moonstone/ScrollableNative` handleResizeWindow method to not blur the focused item if its type is input
+
+
 ## [4.0.3] - 2021-09-29
 
 ### Fixed

--- a/Scrollable/Scrollable.js
+++ b/Scrollable/Scrollable.js
@@ -786,7 +786,7 @@ class ScrollableBase extends Component {
 	handleResizeWindow = () => {
 		const focusedItem = Spotlight.getCurrent();
 
-		if (focusedItem && focusedItem.nodeName === 'INPUT') {
+		if (focusedItem && focusedItem.nodeName !== 'INPUT') {
 			focusedItem.blur();
 		}
 	};

--- a/Scrollable/Scrollable.js
+++ b/Scrollable/Scrollable.js
@@ -786,7 +786,7 @@ class ScrollableBase extends Component {
 	handleResizeWindow = () => {
 		const focusedItem = Spotlight.getCurrent();
 
-		if (focusedItem) {
+		if (focusedItem && focusedItem.nodeName === 'INPUT') {
 			focusedItem.blur();
 		}
 	};

--- a/Scrollable/ScrollableNative.js
+++ b/Scrollable/ScrollableNative.js
@@ -849,6 +849,7 @@ class ScrollableBaseNative extends Component {
 
 	handleResizeWindow = () => {
 		const focusedItem = Spotlight.getCurrent();
+
 		if (focusedItem && focusedItem.nodeName !== 'INPUT') {
 			focusedItem.blur();
 		}

--- a/Scrollable/ScrollableNative.js
+++ b/Scrollable/ScrollableNative.js
@@ -1023,7 +1023,6 @@ class ScrollableBaseNative extends Component {
 			upButtonAriaLabel = scrollUpAriaLabel == null ? $L('scroll up') : scrollUpAriaLabel,
 			rightButtonAriaLabel = scrollRightAriaLabel == null ? $L('scroll right') : scrollRightAriaLabel,
 			leftButtonAriaLabel = scrollLeftAriaLabel == null ? $L('scroll left') : scrollLeftAriaLabel;
-		console.log('scrollableNative');
 
 		return (
 			<UiScrollableBaseNative

--- a/Scrollable/ScrollableNative.js
+++ b/Scrollable/ScrollableNative.js
@@ -849,8 +849,7 @@ class ScrollableBaseNative extends Component {
 
 	handleResizeWindow = () => {
 		const focusedItem = Spotlight.getCurrent();
-
-		if (focusedItem) {
+		if (focusedItem && focusedItem.nodeName !== 'INPUT') {
 			focusedItem.blur();
 		}
 	};
@@ -1024,6 +1023,7 @@ class ScrollableBaseNative extends Component {
 			upButtonAriaLabel = scrollUpAriaLabel == null ? $L('scroll up') : scrollUpAriaLabel,
 			rightButtonAriaLabel = scrollRightAriaLabel == null ? $L('scroll right') : scrollRightAriaLabel,
 			leftButtonAriaLabel = scrollLeftAriaLabel == null ? $L('scroll left') : scrollLeftAriaLabel;
+		console.log('scrollableNative');
 
 		return (
 			<UiScrollableBaseNative


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Adrian Cocoara adrian.cocoara@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fixed qa-scrollerNative, qa-scroller, qa-virtualGridList, qa-virtualGridListNative samples on Android devices so the VKB is always displayed and you can modify the input data.

When the VKB is displaying, a page resizing is triggered, Input loses focus and the VKB disappears. `Scroller` and `ScrollerNative` have a `handleResizeWindow` methods defined which tells the Scroller to blur the focused item. I've made a small change to that method, if the focused item is an input, the input should always be focused.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRN-6762

### Comments