### PR TITLE
Remove unused QA sample Item integrated with other components

### DIFF
--- a/samples/sampler/stories/qa/Item.js
+++ b/samples/sampler/stories/qa/Item.js
@@ -1,9 +1,7 @@
 import {boolean, select, text} from '@enact/storybook-utils/addons/knobs';
 import {storiesOf} from '@storybook/react';
 
-import Button from '@enact/moonstone/Button';
 import Icon from '@enact/moonstone/Icon';
-import Image from '@enact/moonstone/Image';
 import Item from '@enact/moonstone/Item';
 
 import icons from '../default/icons';
@@ -43,20 +41,6 @@ storiesOf('Item', module)
 		() => (
 			<Item disabled={boolean('disabled', Item)}>
 				{text('Children', Item, inputData.extraSpaceText)}
-			</Item>
-		)
-	)
-	.add(
-		'integrated with other components',
-		() => (
-			<Item disabled={boolean('disabled', Item)}>
-				<Button>Click here</Button>
-				{text('Children', Item, 'Hello Item')}
-				<Button>Click here</Button>
-				<Image src="http://lorempixel.com/512/512/city/1/" sizing="fill" alt="lorempixel" />
-				<p>Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa.</p>
-				<p>Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa.</p>
-				<p>Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa.</p>
 			</Item>
 		)
 	)


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Moonstone Item component only supports single-line content but sample with multi-line case exists.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Remove unused QA sample Item integrated with other components

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-10967

### Comments
