### PR TITLE
WRO-6999: Fixed ui-test fail on Jenkins

### DIFF
--- a/tests/ui/specs/ActivityPanels/ActivityPanels-specs.js
+++ b/tests/ui/specs/ActivityPanels/ActivityPanels-specs.js
@@ -58,9 +58,6 @@ describe('ActivityPanels', function () {
 			await Page.waitTransitionEnd(5000, undefined, () => {
 				Page.breadcrumbHeader.click();
 			}, []);
-			await Page.waitTransitionEnd(5000, undefined, () => {
-				Page.breadcrumbHeader.click();
-			}, []);
 
 			expect((await Page.panelTitle).toLowerCase()).to.equal('FIRST'.toLowerCase());
 		});

--- a/tests/ui/specs/ActivityPanels/ActivityPanels-specs.js
+++ b/tests/ui/specs/ActivityPanels/ActivityPanels-specs.js
@@ -12,18 +12,16 @@ describe('ActivityPanels', function () {
 	});
 
 	it('should have breadcrumb on second panel', async function () {
-		await Page.waitTransitionEnd(2000, undefined, () => {
+		await Page.waitTransitionEnd(5000, undefined, () => {
 			Page.button1.click();
 		}, []);
-
-		Page.button1.click();
 
 		expect(await Page.breadcrumbHeader.getText()).to.include('01');
 	});
 
 	describe('Transition', function () {
 		it('should move from first panel to the second', async function () {
-			await Page.waitTransitionEnd(2000, undefined, () => {
+			await Page.waitTransitionEnd(5000, undefined, () => {
 				Page.button1.click();
 			}, []);
 
@@ -31,16 +29,16 @@ describe('ActivityPanels', function () {
 		});
 
 		it('should navigate to Last Focused', async function () {
-			await Page.waitTransitionEnd(2000, undefined, () => {
+			await Page.waitTransitionEnd(5000, undefined, () => {
 				Page.item1.click();
 			}, []);
-			await Page.waitTransitionEnd(2000, undefined, () => {
+			await Page.waitTransitionEnd(5000, undefined, () => {
 				Page.item5.click();
 			}, []);
-			await Page.waitTransitionEnd(2000, undefined, () => {
+			await Page.waitTransitionEnd(5000, undefined, () => {
 				Page.button4.click();
 			}, []);
-			await Page.waitTransitionEnd(2000, undefined, () => {
+			await Page.waitTransitionEnd(5000, undefined, () => {
 				Page.item2.click();
 			}, []);
 
@@ -48,28 +46,19 @@ describe('ActivityPanels', function () {
 		});
 
 		it('should navigate back to the First panel from clicking on breadcrumb', async function () {
-			await Page.waitTransitionEnd(2000, 'one', () => {
+			await Page.waitTransitionEnd(5000, undefined, () => {
 				Page.item1.click();
 			}, []);
-			await Page.waitTransitionEnd(2000, 'two', () => {
+			await Page.waitTransitionEnd(5000, undefined, () => {
 				Page.item5.click();
 			}, []);
-			await Page.waitTransitionEnd(2000, 'three', () => {
-				Page.button4.click();
-			}, []);
-			await Page.waitTransitionEnd(2000, 'four', () => {
-				Page.item2.click();
-			}, []);
-			await Page.waitTransitionEnd(2000, 'five', () => {
+			await Page.waitTransitionEnd(5000, undefined, () => {
 				Page.breadcrumbHeader.click();
 			}, []);
-			await Page.waitTransitionEnd(2000, 'six', () => {
+			await Page.waitTransitionEnd(5000, undefined, () => {
 				Page.breadcrumbHeader.click();
 			}, []);
-			await Page.waitTransitionEnd(2000, 'seven', () => {
-				Page.breadcrumbHeader.click();
-			}, []);
-			await Page.waitTransitionEnd(2000, 'eight', () => {
+			await Page.waitTransitionEnd(5000, undefined, () => {
 				Page.breadcrumbHeader.click();
 			}, []);
 
@@ -77,22 +66,22 @@ describe('ActivityPanels', function () {
 		});
 
 		it('should navigate back to the Third panel from clicking on breadcrumb', async function () {
-			await Page.waitTransitionEnd(2000, 'one', () => {
+			await Page.waitTransitionEnd(5000, 'one', () => {
 				Page.item1.click();
 			}, []);
-			await Page.waitTransitionEnd(2000, 'two', () => {
+			await Page.waitTransitionEnd(5000, 'two', () => {
 				Page.item5.click();
 			}, []);
-			await Page.waitTransitionEnd(2000, 'three', () => {
+			await Page.waitTransitionEnd(5000, 'three', () => {
 				Page.breadcrumbHeader.click();
 			}, []);
-			await Page.waitTransitionEnd(2000, 'four', () => {
+			await Page.waitTransitionEnd(5000, 'four', () => {
 				Page.item8.click();
 			}, []);
-			await Page.waitTransitionEnd(2000, 'five', () => {
+			await Page.waitTransitionEnd(5000, 'five', () => {
 				Page.button4.click();
 			}, []);
-			await Page.waitTransitionEnd(2000, 'six', () => {
+			await Page.waitTransitionEnd(5000, 'six', () => {
 				Page.breadcrumbHeader.click();
 			}, []);
 
@@ -101,13 +90,13 @@ describe('ActivityPanels', function () {
 
 		it('should move from first panel to the third', async function () {
 			await Page.button1.moveTo();
-			await Page.waitTransitionEnd(2000, undefined, () => {
+			await Page.waitTransitionEnd(5000, undefined, () => {
 				Page.spotlightSelect();
 			}, []);
 
 			expect((await Page.panelTitle).toLowerCase()).to.equal('SECOND'.toLowerCase());
 			await Page.item8.moveTo();
-			await Page.waitTransitionEnd(2000, undefined, () => {
+			await Page.waitTransitionEnd(5000, undefined, () => {
 				Page.spotlightSelect();
 			}, []);
 
@@ -116,26 +105,26 @@ describe('ActivityPanels', function () {
 
 		it('should move to first panel from the third', async function () {
 			await Page.button1.moveTo();
-			await Page.waitTransitionEnd(2000, undefined, () => {
+			await Page.waitTransitionEnd(5000, undefined, () => {
 				Page.spotlightSelect();
 			}, []);
 
 			expect((await Page.panelTitle).toLowerCase()).to.equal('SECOND'.toLowerCase());
 			await Page.item8.moveTo();
-			await Page.waitTransitionEnd(2000, undefined, () => {
+			await Page.waitTransitionEnd(5000, undefined, () => {
 				Page.spotlightSelect();
 			}, []);
 
 			expect((await Page.panelTitle).toLowerCase()).to.equal('THIRD'.toLowerCase());
 			await Page.breadcrumbHeader.moveTo();
-			await Page.waitTransitionEnd(2000, undefined, () => {
+			await Page.waitTransitionEnd(5000, undefined, () => {
 				Page.spotlightSelect();
 			}, []);
 
 			expect((await Page.panelTitle).toLowerCase()).to.equal('SECOND'.toLowerCase());
 			await Page.item8.moveTo();
 			await Page.breadcrumbHeader.moveTo();
-			await Page.waitTransitionEnd(2000, undefined, () => {
+			await Page.waitTransitionEnd(5000, undefined, () => {
 				Page.spotlightSelect();
 			}, []);
 
@@ -143,11 +132,11 @@ describe('ActivityPanels', function () {
 		});
 
 		it('should transition back to First panel with back key', async function () {
-			await Page.waitTransitionEnd(2000, undefined, () => {
+			await Page.waitTransitionEnd(5000, undefined, () => {
 				Page.button1.click();
 			}, []);
 			expect((await Page.panelTitle).toLowerCase()).to.equal('SECOND'.toLowerCase());
-			await Page.waitTransitionEnd(2000, undefined, () => {
+			await Page.waitTransitionEnd(5000, undefined, () => {
 				Page.backKey();
 			}, []);
 
@@ -163,10 +152,10 @@ describe('ActivityPanels', function () {
 		describe('pointer', function () {
 			// The ESC button (Back Key) does _not_ unset the pointer mode and does _not_ focus [ENYO-5865] [ENYO-5882]
 			it('should Not spot last focused item when transitioning back', async function () {
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(5000, undefined, () => {
 					Page.item2.click();
 				}, []);
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(5000, undefined, () => {
 					Page.backKey();
 				}, []);
 
@@ -175,11 +164,11 @@ describe('ActivityPanels', function () {
 
 			// The ESC button (Back Key) does _not_ unset the pointer mode and does _not_ focus [ENYO-5865] [ENYO-5882]
 			it('should Not spot last focused item when transitioning back after moving pointer', async function () {
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(5000, undefined, () => {
 					Page.item2.click();
 				}, []);
 				Page.item8.moveTo();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(5000, undefined, () => {
 					Page.backKey();
 				}, []);
 
@@ -190,7 +179,7 @@ describe('ActivityPanels', function () {
 
 		describe('5way', function () {
 			it('should spot first item on second panel', async function () {
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(5000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
@@ -199,11 +188,11 @@ describe('ActivityPanels', function () {
 
 			it('should spot last focused item when transitioning back using back key', async function () {
 				Page.spotlightDown();
-				await Page.waitTransitionEnd(2000, 'panel open', () => {
+				await Page.waitTransitionEnd(5000, 'panel open', () => {
 					Page.spotlightSelect();
 				}, []);
 				expect(await Page.item5.isFocused()).to.be.true();
-				await Page.waitTransitionEnd(2000, 'panel back', () => {
+				await Page.waitTransitionEnd(5000, 'panel back', () => {
 					Page.backKey();
 				}, []);
 
@@ -215,12 +204,12 @@ describe('ActivityPanels', function () {
 			it('should spot last focused item when transitioning back from Third panel', async function () {
 				Page.spotlightDown();
 				Page.spotlightDown();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(5000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
 				expect(await Page.item5.isFocused(), 'Item 5 focus').to.be.true();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(5000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
@@ -230,7 +219,7 @@ describe('ActivityPanels', function () {
 				Page.spotlightLeft();
 				Page.spotlightLeft();
 				expect(await Page.breadcrumb.isFocused(), 'Breadcrumb focus').to.be.true();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(5000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
@@ -239,22 +228,22 @@ describe('ActivityPanels', function () {
 
 			it('should spot last focused item in first panel when transitioning after deep navigation', async function () {
 				Page.spotlightDown();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(5000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
 				Page.spotlightDown();
 				expect(await Page.item6.isFocused(), 'Item 6 focus').to.be.true();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(5000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
 				expect(await Page.button3.isFocused(), 'Button 3 focus').to.be.true();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(5000, undefined, () => {
 					Page.backKey();
 				}, []);
 				expect(await Page.item6.isFocused(), 'Item 6 refocus').to.be.true();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(5000, undefined, () => {
 					Page.backKey();
 				}, []);
 				expect(await Page.item2.isFocused(), 'Item 2 refocus').to.be.true();
@@ -266,7 +255,7 @@ describe('ActivityPanels', function () {
 				await Page.spotlightDown();
 				await Page.spotlightDown();
 				await Page.spotlightDown();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(5000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
@@ -285,18 +274,18 @@ describe('ActivityPanels', function () {
 			});
 
 			it('should spot the seventh item on last panel', async function () {
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(5000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(5000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(5000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 				await Page.spotlightRight();
 				await Page.spotlightRight();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(5000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
@@ -312,13 +301,13 @@ describe('ActivityPanels', function () {
 			it('should spot third item on first panel', async function () {
 				await Page.spotlightDown();
 				await Page.spotlightDown();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(5000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
 				expect(await Page.item5.isFocused()).to.be.true();
 				await Page.spotlightLeft();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(5000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
@@ -329,18 +318,18 @@ describe('ActivityPanels', function () {
 		describe('5way and pointer', function () {
 			it('should not spot in None panel', async function () {
 				await Page.button1.moveTo();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(5000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
 				expect((await Page.panelTitle).toLowerCase()).to.equal('SECOND'.toLowerCase());
 				await Page.item8.moveTo();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(5000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
 				expect(await Page.button3.isFocused()).to.be.true();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(5000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
@@ -349,25 +338,25 @@ describe('ActivityPanels', function () {
 
 			it('should spot default item in Default panel', async function () {
 				await Page.button1.moveTo();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(5000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
 				expect((await Page.panelTitle).toLowerCase()).to.equal('SECOND'.toLowerCase());
 				await Page.item8.moveTo();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(5000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
 				expect((await Page.panelTitle).toLowerCase()).to.equal('THIRD'.toLowerCase());
 				await Page.button4.moveTo();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(5000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
 				expect((await Page.panelTitle).toLowerCase()).to.equal('NONE'.toLowerCase());
 				await Page.button1.moveTo();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(5000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
@@ -376,18 +365,18 @@ describe('ActivityPanels', function () {
 
 			it('should re-spot last focused in last focused panel', async function () {
 				await Page.button1.moveTo();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(5000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
 				expect(await Page.item5.isFocused(), 'item 5 focus 1').to.be.true();
 				await Page.item8.moveTo();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(5000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
 				expect(await Page.button3.isFocused(), 'button 3 focus').to.be.true();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(5000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
@@ -395,18 +384,18 @@ describe('ActivityPanels', function () {
 				await Page.spotlightDown();
 				expect(await Page.breadcrumb.isFocused(), 'breadcrumb focus').to.be.true();
 				await Page.button1.moveTo();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(5000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
 				expect(await Page.item5.isFocused(), 'item 5 focus 2').to.be.true();
 				// Focus to item 6 so it can be last-focused item when returning
 				await Page.spotlightDown();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(5000, undefined, () => {
 					Page.backKey();
 				}, []);
 				await Page.spotlightDown();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(5000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
@@ -415,21 +404,21 @@ describe('ActivityPanels', function () {
 
 			it('should spot last focused item when transitioning back with Back key, deep navigation', async function () {
 				await Page.item3.moveTo();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(5000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
 				expect(await Page.item5.isFocused()).to.be.true();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(5000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
 				expect(await Page.button3.isFocused()).to.be.true();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(5000, undefined, () => {
 					Page.backKey();
 				}, []);
 				expect(await Page.item5.isFocused()).to.be.true();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(5000, undefined, () => {
 					Page.backKey();
 				}, []);
 

--- a/tests/ui/specs/ActivityPanels/ActivityPanels-specs.js
+++ b/tests/ui/specs/ActivityPanels/ActivityPanels-specs.js
@@ -12,7 +12,7 @@ describe('ActivityPanels', function () {
 	});
 
 	it('should have breadcrumb on second panel', async function () {
-		await Page.waitTransitionEnd(5000, undefined, () => {
+		await Page.waitTransitionEnd(2000, undefined, () => {
 			Page.button1.click();
 		}, []);
 
@@ -23,7 +23,7 @@ describe('ActivityPanels', function () {
 
 	describe('Transition', function () {
 		it('should move from first panel to the second', async function () {
-			await Page.waitTransitionEnd(5000, undefined, () => {
+			await Page.waitTransitionEnd(2000, undefined, () => {
 				Page.button1.click();
 			}, []);
 
@@ -31,16 +31,16 @@ describe('ActivityPanels', function () {
 		});
 
 		it('should navigate to Last Focused', async function () {
-			await Page.waitTransitionEnd(5000, undefined, () => {
+			await Page.waitTransitionEnd(2000, undefined, () => {
 				Page.item1.click();
 			}, []);
-			await Page.waitTransitionEnd(5000, undefined, () => {
+			await Page.waitTransitionEnd(2000, undefined, () => {
 				Page.item5.click();
 			}, []);
-			await Page.waitTransitionEnd(5000, undefined, () => {
+			await Page.waitTransitionEnd(2000, undefined, () => {
 				Page.button4.click();
 			}, []);
-			await Page.waitTransitionEnd(5000, undefined, () => {
+			await Page.waitTransitionEnd(2000, undefined, () => {
 				Page.item2.click();
 			}, []);
 
@@ -48,28 +48,28 @@ describe('ActivityPanels', function () {
 		});
 
 		it('should navigate back to the First panel from clicking on breadcrumb', async function () {
-			await Page.waitTransitionEnd(5000, undefined, () => {
+			await Page.waitTransitionEnd(2000, 'one', () => {
 				Page.item1.click();
 			}, []);
-			await Page.waitTransitionEnd(5000, undefined, () => {
+			await Page.waitTransitionEnd(2000, 'two', () => {
 				Page.item5.click();
 			}, []);
-			await Page.waitTransitionEnd(5000, undefined, () => {
+			await Page.waitTransitionEnd(2000, 'three', () => {
 				Page.button4.click();
 			}, []);
-			await Page.waitTransitionEnd(5000, undefined, () => {
+			await Page.waitTransitionEnd(2000, 'four', () => {
 				Page.item2.click();
 			}, []);
-			await Page.waitTransitionEnd(5000, undefined, () => {
+			await Page.waitTransitionEnd(2000, 'five', () => {
 				Page.breadcrumbHeader.click();
 			}, []);
-			await Page.waitTransitionEnd(5000, undefined, () => {
+			await Page.waitTransitionEnd(2000, 'six', () => {
 				Page.breadcrumbHeader.click();
 			}, []);
-			await Page.waitTransitionEnd(5000, undefined, () => {
+			await Page.waitTransitionEnd(2000, 'seven', () => {
 				Page.breadcrumbHeader.click();
 			}, []);
-			await Page.waitTransitionEnd(5000, undefined, () => {
+			await Page.waitTransitionEnd(2000, 'eight', () => {
 				Page.breadcrumbHeader.click();
 			}, []);
 
@@ -77,22 +77,22 @@ describe('ActivityPanels', function () {
 		});
 
 		it('should navigate back to the Third panel from clicking on breadcrumb', async function () {
-			await Page.waitTransitionEnd(5000, 'one', () => {
+			await Page.waitTransitionEnd(2000, 'one', () => {
 				Page.item1.click();
 			}, []);
-			await Page.waitTransitionEnd(5000, 'two', () => {
+			await Page.waitTransitionEnd(2000, 'two', () => {
 				Page.item5.click();
 			}, []);
-			await Page.waitTransitionEnd(5000, 'three', () => {
+			await Page.waitTransitionEnd(2000, 'three', () => {
 				Page.breadcrumbHeader.click();
 			}, []);
-			await Page.waitTransitionEnd(5000, 'four', () => {
+			await Page.waitTransitionEnd(2000, 'four', () => {
 				Page.item8.click();
 			}, []);
-			await Page.waitTransitionEnd(5000, 'five', () => {
+			await Page.waitTransitionEnd(2000, 'five', () => {
 				Page.button4.click();
 			}, []);
-			await Page.waitTransitionEnd(5000, 'six', () => {
+			await Page.waitTransitionEnd(2000, 'six', () => {
 				Page.breadcrumbHeader.click();
 			}, []);
 
@@ -101,13 +101,13 @@ describe('ActivityPanels', function () {
 
 		it('should move from first panel to the third', async function () {
 			await Page.button1.moveTo();
-			await Page.waitTransitionEnd(5000, undefined, () => {
+			await Page.waitTransitionEnd(2000, undefined, () => {
 				Page.spotlightSelect();
 			}, []);
 
 			expect((await Page.panelTitle).toLowerCase()).to.equal('SECOND'.toLowerCase());
 			await Page.item8.moveTo();
-			await Page.waitTransitionEnd(5000, undefined, () => {
+			await Page.waitTransitionEnd(2000, undefined, () => {
 				Page.spotlightSelect();
 			}, []);
 
@@ -116,26 +116,26 @@ describe('ActivityPanels', function () {
 
 		it('should move to first panel from the third', async function () {
 			await Page.button1.moveTo();
-			await Page.waitTransitionEnd(5000, undefined, () => {
+			await Page.waitTransitionEnd(2000, undefined, () => {
 				Page.spotlightSelect();
 			}, []);
 
 			expect((await Page.panelTitle).toLowerCase()).to.equal('SECOND'.toLowerCase());
 			await Page.item8.moveTo();
-			await Page.waitTransitionEnd(5000, undefined, () => {
+			await Page.waitTransitionEnd(2000, undefined, () => {
 				Page.spotlightSelect();
 			}, []);
 
 			expect((await Page.panelTitle).toLowerCase()).to.equal('THIRD'.toLowerCase());
 			await Page.breadcrumbHeader.moveTo();
-			await Page.waitTransitionEnd(5000, undefined, () => {
+			await Page.waitTransitionEnd(2000, undefined, () => {
 				Page.spotlightSelect();
 			}, []);
 
 			expect((await Page.panelTitle).toLowerCase()).to.equal('SECOND'.toLowerCase());
 			await Page.item8.moveTo();
 			await Page.breadcrumbHeader.moveTo();
-			await Page.waitTransitionEnd(5000, undefined, () => {
+			await Page.waitTransitionEnd(2000, undefined, () => {
 				Page.spotlightSelect();
 			}, []);
 
@@ -143,11 +143,11 @@ describe('ActivityPanels', function () {
 		});
 
 		it('should transition back to First panel with back key', async function () {
-			await Page.waitTransitionEnd(5000, undefined, () => {
+			await Page.waitTransitionEnd(2000, undefined, () => {
 				Page.button1.click();
 			}, []);
 			expect((await Page.panelTitle).toLowerCase()).to.equal('SECOND'.toLowerCase());
-			await Page.waitTransitionEnd(5000, undefined, () => {
+			await Page.waitTransitionEnd(2000, undefined, () => {
 				Page.backKey();
 			}, []);
 
@@ -163,10 +163,10 @@ describe('ActivityPanels', function () {
 		describe('pointer', function () {
 			// The ESC button (Back Key) does _not_ unset the pointer mode and does _not_ focus [ENYO-5865] [ENYO-5882]
 			it('should Not spot last focused item when transitioning back', async function () {
-				await Page.waitTransitionEnd(5000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.item2.click();
 				}, []);
-				await Page.waitTransitionEnd(5000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.backKey();
 				}, []);
 
@@ -175,11 +175,11 @@ describe('ActivityPanels', function () {
 
 			// The ESC button (Back Key) does _not_ unset the pointer mode and does _not_ focus [ENYO-5865] [ENYO-5882]
 			it('should Not spot last focused item when transitioning back after moving pointer', async function () {
-				await Page.waitTransitionEnd(5000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.item2.click();
 				}, []);
 				Page.item8.moveTo();
-				await Page.waitTransitionEnd(5000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.backKey();
 				}, []);
 
@@ -190,7 +190,7 @@ describe('ActivityPanels', function () {
 
 		describe('5way', function () {
 			it('should spot first item on second panel', async function () {
-				await Page.waitTransitionEnd(5000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
@@ -199,11 +199,11 @@ describe('ActivityPanels', function () {
 
 			it('should spot last focused item when transitioning back using back key', async function () {
 				Page.spotlightDown();
-				await Page.waitTransitionEnd(5000, 'panel open', () => {
+				await Page.waitTransitionEnd(2000, 'panel open', () => {
 					Page.spotlightSelect();
 				}, []);
 				expect(await Page.item5.isFocused()).to.be.true();
-				await Page.waitTransitionEnd(5000, 'panel back', () => {
+				await Page.waitTransitionEnd(2000, 'panel back', () => {
 					Page.backKey();
 				}, []);
 
@@ -215,12 +215,12 @@ describe('ActivityPanels', function () {
 			it('should spot last focused item when transitioning back from Third panel', async function () {
 				Page.spotlightDown();
 				Page.spotlightDown();
-				await Page.waitTransitionEnd(5000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
 				expect(await Page.item5.isFocused(), 'Item 5 focus').to.be.true();
-				await Page.waitTransitionEnd(5000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
@@ -230,7 +230,7 @@ describe('ActivityPanels', function () {
 				Page.spotlightLeft();
 				Page.spotlightLeft();
 				expect(await Page.breadcrumb.isFocused(), 'Breadcrumb focus').to.be.true();
-				await Page.waitTransitionEnd(5000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
@@ -239,22 +239,22 @@ describe('ActivityPanels', function () {
 
 			it('should spot last focused item in first panel when transitioning after deep navigation', async function () {
 				Page.spotlightDown();
-				await Page.waitTransitionEnd(5000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
 				Page.spotlightDown();
 				expect(await Page.item6.isFocused(), 'Item 6 focus').to.be.true();
-				await Page.waitTransitionEnd(5000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
 				expect(await Page.button3.isFocused(), 'Button 3 focus').to.be.true();
-				await Page.waitTransitionEnd(5000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.backKey();
 				}, []);
 				expect(await Page.item6.isFocused(), 'Item 6 refocus').to.be.true();
-				await Page.waitTransitionEnd(5000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.backKey();
 				}, []);
 				expect(await Page.item2.isFocused(), 'Item 2 refocus').to.be.true();
@@ -266,7 +266,7 @@ describe('ActivityPanels', function () {
 				await Page.spotlightDown();
 				await Page.spotlightDown();
 				await Page.spotlightDown();
-				await Page.waitTransitionEnd(5000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
@@ -285,18 +285,18 @@ describe('ActivityPanels', function () {
 			});
 
 			it('should spot the seventh item on last panel', async function () {
-				await Page.waitTransitionEnd(5000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
-				await Page.waitTransitionEnd(5000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
-				await Page.waitTransitionEnd(5000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 				await Page.spotlightRight();
 				await Page.spotlightRight();
-				await Page.waitTransitionEnd(5000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
@@ -312,13 +312,13 @@ describe('ActivityPanels', function () {
 			it('should spot third item on first panel', async function () {
 				await Page.spotlightDown();
 				await Page.spotlightDown();
-				await Page.waitTransitionEnd(5000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
 				expect(await Page.item5.isFocused()).to.be.true();
 				await Page.spotlightLeft();
-				await Page.waitTransitionEnd(5000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
@@ -329,18 +329,18 @@ describe('ActivityPanels', function () {
 		describe('5way and pointer', function () {
 			it('should not spot in None panel', async function () {
 				await Page.button1.moveTo();
-				await Page.waitTransitionEnd(5000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
 				expect((await Page.panelTitle).toLowerCase()).to.equal('SECOND'.toLowerCase());
 				await Page.item8.moveTo();
-				await Page.waitTransitionEnd(5000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
 				expect(await Page.button3.isFocused()).to.be.true();
-				await Page.waitTransitionEnd(5000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
@@ -349,25 +349,25 @@ describe('ActivityPanels', function () {
 
 			it('should spot default item in Default panel', async function () {
 				await Page.button1.moveTo();
-				await Page.waitTransitionEnd(5000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
 				expect((await Page.panelTitle).toLowerCase()).to.equal('SECOND'.toLowerCase());
 				await Page.item8.moveTo();
-				await Page.waitTransitionEnd(5000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
 				expect((await Page.panelTitle).toLowerCase()).to.equal('THIRD'.toLowerCase());
 				await Page.button4.moveTo();
-				await Page.waitTransitionEnd(5000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
 				expect((await Page.panelTitle).toLowerCase()).to.equal('NONE'.toLowerCase());
 				await Page.button1.moveTo();
-				await Page.waitTransitionEnd(5000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
@@ -376,18 +376,18 @@ describe('ActivityPanels', function () {
 
 			it('should re-spot last focused in last focused panel', async function () {
 				await Page.button1.moveTo();
-				await Page.waitTransitionEnd(5000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
 				expect(await Page.item5.isFocused(), 'item 5 focus 1').to.be.true();
 				await Page.item8.moveTo();
-				await Page.waitTransitionEnd(5000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
 				expect(await Page.button3.isFocused(), 'button 3 focus').to.be.true();
-				await Page.waitTransitionEnd(5000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
@@ -395,18 +395,18 @@ describe('ActivityPanels', function () {
 				await Page.spotlightDown();
 				expect(await Page.breadcrumb.isFocused(), 'breadcrumb focus').to.be.true();
 				await Page.button1.moveTo();
-				await Page.waitTransitionEnd(5000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
 				expect(await Page.item5.isFocused(), 'item 5 focus 2').to.be.true();
 				// Focus to item 6 so it can be last-focused item when returning
 				await Page.spotlightDown();
-				await Page.waitTransitionEnd(5000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.backKey();
 				}, []);
 				await Page.spotlightDown();
-				await Page.waitTransitionEnd(5000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
@@ -415,21 +415,21 @@ describe('ActivityPanels', function () {
 
 			it('should spot last focused item when transitioning back with Back key, deep navigation', async function () {
 				await Page.item3.moveTo();
-				await Page.waitTransitionEnd(5000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
 				expect(await Page.item5.isFocused()).to.be.true();
-				await Page.waitTransitionEnd(5000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				}, []);
 
 				expect(await Page.button3.isFocused()).to.be.true();
-				await Page.waitTransitionEnd(5000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.backKey();
 				}, []);
 				expect(await Page.item5.isFocused()).to.be.true();
-				await Page.waitTransitionEnd(5000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.backKey();
 				}, []);
 

--- a/tests/ui/specs/CheckboxItem/CheckboxItem-specs.js
+++ b/tests/ui/specs/CheckboxItem/CheckboxItem-specs.js
@@ -28,20 +28,20 @@ describe('CheckboxItem', function () {
 				expect(await checkboxItem.isBefore).to.be.true();
 			});
 
-			it('should have icon to the left of marquee text', async function () {
-				await expectOrdering(checkboxItem.icon, checkboxItem.value);
+			it('should have icon to the left of marquee text', function () {
+				expectOrdering(checkboxItem.icon, checkboxItem.value);
 			});
 
 			describe('5-way', function () {
-				it('should check the item when selected - [GT-21124]', function () {
-					Page.spotlightSelect();
-					expectChecked(checkboxItem);
+				it('should check the item when selected - [GT-21124]', async function () {
+					await Page.spotlightSelect();
+					await expectChecked(checkboxItem);
 				});
 
-				it('should re-uncheck the item when selected twice', function () {
-					Page.spotlightSelect();
-					Page.spotlightSelect();
-					expectUnchecked(checkboxItem);
+				it('should re-uncheck the item when selected twice', async function () {
+					await Page.spotlightSelect();
+					await Page.spotlightSelect();
+					await expectUnchecked(checkboxItem);
 				});
 
 				it('should display check icon when selected', async function () {
@@ -174,7 +174,7 @@ describe('CheckboxItem', function () {
 			it('should have two inlined checkboxes positioned inlined', async function () {
 				const checkboxItem2 = await Page.components.checkboxInlineAfter.self;
 
-				await expectInline(await checkboxItem.self, checkboxItem2);
+				expectInline(await checkboxItem.self, checkboxItem2);
 			});
 
 			it('should have correct text', async function () {
@@ -325,14 +325,14 @@ describe('CheckboxItem', function () {
 		it('should have icon to the right of text when default', async function () {
 			const checkboxItem = await Page.components.checkboxDefault;
 
-			await expectOrdering(checkboxItem.value, checkboxItem.icon);
+			expectOrdering(checkboxItem.value, checkboxItem.icon);
 		});
 
 		it('should have two inlined checkboxes positioned inlined', async function () {
 			const checkboxItem1 = await Page.components.checkboxInline.self;
 			const checkboxItem2 = await Page.components.checkboxInlineAfter.self;
 
-			await expectInline(checkboxItem1, checkboxItem2);
+			expectInline(checkboxItem1, checkboxItem2);
 		});
 	});
 });

--- a/tests/ui/specs/CheckboxItem/CheckboxItem-specs.js
+++ b/tests/ui/specs/CheckboxItem/CheckboxItem-specs.js
@@ -21,15 +21,15 @@ describe('CheckboxItem', function () {
 			});
 
 			it('should not be checked', async function () {
-				expectUnchecked(checkboxItem);
+				await expectUnchecked(checkboxItem);
 			});
 
 			it('should display icon before the text', async function () {
 				expect(await checkboxItem.isBefore).to.be.true();
 			});
 
-			it('should have icon to the left of marquee text', function () {
-				expectOrdering(checkboxItem.icon, checkboxItem.value);
+			it('should have icon to the left of marquee text', async function () {
+				await expectOrdering(checkboxItem.icon, checkboxItem.value);
 			});
 
 			describe('5-way', function () {
@@ -64,13 +64,13 @@ describe('CheckboxItem', function () {
 			describe('pointer', function () {
 				it('should check the item when clicked', async function () {
 					await checkboxItem.self.click();
-					expectChecked(checkboxItem);
+					await expectChecked(checkboxItem);
 				});
 
 				it('should re-uncheck the item when clicked twice', async function () {
 					await checkboxItem.self.click();
 					await checkboxItem.self.click();
-					expectUnchecked(checkboxItem);
+					await expectUnchecked(checkboxItem);
 				});
 
 				it('should display check icon when clicked', async  function () {
@@ -88,7 +88,7 @@ describe('CheckboxItem', function () {
 			});
 
 			it('should be checked', async function () {
-				expectChecked(checkboxItem);
+				await expectChecked(checkboxItem);
 			});
 
 			it('should display correct icon - [GT-21121]', async function () {
@@ -99,27 +99,27 @@ describe('CheckboxItem', function () {
 				it('should uncheck the item when selected', async function () {
 					await checkboxItem.focus();
 					await Page.spotlightSelect();
-					expectUnchecked(checkboxItem);
+					await expectUnchecked(checkboxItem);
 				});
 
 				it('should re-check the item when selected twice', async function () {
 					await checkboxItem.focus();
 					await Page.spotlightSelect();
 					await Page.spotlightSelect();
-					expectChecked(checkboxItem);
+					await expectChecked(checkboxItem);
 				});
 			});
 
 			describe('pointer', function () {
 				it('should uncheck the item when clicked', async function () {
 					await checkboxItem.self.click();
-					expectUnchecked(checkboxItem);
+					await expectUnchecked(checkboxItem);
 				});
 
 				it('should re-check the item when clicked twice', async function () {
 					await checkboxItem.self.click();
 					await checkboxItem.self.click();
-					expectChecked(checkboxItem);
+					await expectChecked(checkboxItem);
 				});
 			});
 		});
@@ -132,7 +132,7 @@ describe('CheckboxItem', function () {
 			});
 
 			it('should be checked', async function () {
-				expectChecked(checkboxItemIconAfter);
+				await expectChecked(checkboxItemIconAfter);
 			});
 
 			it('should display icon after the text', async function () {
@@ -143,27 +143,27 @@ describe('CheckboxItem', function () {
 				it('should uncheck the item when selected', async function () {
 					await checkboxItemIconAfter.focus();
 					await Page.spotlightSelect();
-					expectUnchecked(checkboxItemIconAfter);
+					await expectUnchecked(checkboxItemIconAfter);
 				});
 
 				it('should re-check the item when selected twice', async function () {
 					await checkboxItemIconAfter.focus();
 					await Page.spotlightSelect();
 					await Page.spotlightSelect();
-					expectChecked(checkboxItemIconAfter);
+					await expectChecked(checkboxItemIconAfter);
 				});
 			});
 
 			describe('pointer', function () {
 				it('should uncheck the item when clicked', async function () {
 					await checkboxItemIconAfter.self.click();
-					expectUnchecked(checkboxItemIconAfter);
+					await expectUnchecked(checkboxItemIconAfter);
 				});
 
 				it('should re-check the item when clicked twice', async function () {
 					await checkboxItemIconAfter.self.click();
 					await checkboxItemIconAfter.self.click();
-					expectChecked(checkboxItemIconAfter);
+					await expectChecked(checkboxItemIconAfter);
 				});
 			});
 		});
@@ -174,7 +174,7 @@ describe('CheckboxItem', function () {
 			it('should have two inlined checkboxes positioned inlined', async function () {
 				const checkboxItem2 = await Page.components.checkboxInlineAfter.self;
 
-				expectInline(await checkboxItem.self, checkboxItem2);
+				await expectInline(await checkboxItem.self, checkboxItem2);
 			});
 
 			it('should have correct text', async function () {
@@ -182,7 +182,7 @@ describe('CheckboxItem', function () {
 			});
 
 			it('should be checked', async function () {
-				expectChecked(checkboxItem);
+				await expectChecked(checkboxItem);
 			});
 
 			it('should display icon before the text', async function () {
@@ -197,27 +197,27 @@ describe('CheckboxItem', function () {
 				it('should uncheck the item when selected', async function () {
 					await checkboxItem.focus();
 					await Page.spotlightSelect();
-					expectUnchecked(checkboxItem);
+					await expectUnchecked(checkboxItem);
 				});
 
 				it('should re-check the item when selected twice', async function () {
 					await checkboxItem.focus();
 					await Page.spotlightSelect();
 					await Page.spotlightSelect();
-					expectChecked(checkboxItem);
+					await expectChecked(checkboxItem);
 				});
 			});
 
 			describe('pointer', function () {
 				it('should uncheck the item when clicked', async function () {
 					await checkboxItem.self.click();
-					expectUnchecked(checkboxItem);
+					await expectUnchecked(checkboxItem);
 				});
 
 				it('should re-check the item when clicked twice', async function () {
 					await checkboxItem.self.click();
 					await checkboxItem.self.click();
-					expectChecked(checkboxItem);
+					await expectChecked(checkboxItem);
 				});
 			});
 		});
@@ -230,7 +230,7 @@ describe('CheckboxItem', function () {
 			});
 
 			it('should be checked', async function () {
-				expectChecked(checkboxItem);
+				await expectChecked(checkboxItem);
 			});
 
 			it('should display icon after the text', async function () {
@@ -245,27 +245,27 @@ describe('CheckboxItem', function () {
 				it('should uncheck the item when selected', async function () {
 					await checkboxItem.focus();
 					await Page.spotlightSelect();
-					expectUnchecked(checkboxItem);
+					await expectUnchecked(checkboxItem);
 				});
 
 				it('should re-check the item when selected twice', async function () {
 					await checkboxItem.focus();
 					await Page.spotlightSelect();
 					await Page.spotlightSelect();
-					expectChecked(checkboxItem);
+					await expectChecked(checkboxItem);
 				});
 			});
 
 			describe('pointer', function () {
 				it('should uncheck the item when clicked', async function () {
 					await checkboxItem.self.click();
-					expectUnchecked(checkboxItem);
+					await expectUnchecked(checkboxItem);
 				});
 
 				it('should re-check the item when clicked twice', async function () {
 					await checkboxItem.self.click();
 					await checkboxItem.self.click();
-					expectChecked(checkboxItem);
+					await expectChecked(checkboxItem);
 				});
 			});
 		});
@@ -282,7 +282,7 @@ describe('CheckboxItem', function () {
 			});
 
 			it('should be checked', async function () {
-				expectChecked(checkboxItem);
+				await expectChecked(checkboxItem);
 			});
 
 			it('should display icon before the text', async function () {
@@ -297,14 +297,14 @@ describe('CheckboxItem', function () {
 				});
 				it('should not uncheck the item when selected', async function () {
 					await Page.spotlightDown();
-					expectChecked(checkboxItem);
+					await expectChecked(checkboxItem);
 				});
 			});
 
 			describe('pointer', function () {
 				it('should not uncheck the item when clicked', async function () {
 					await checkboxItem.self.click();
-					expectChecked(checkboxItem);
+					await expectChecked(checkboxItem);
 				});
 			});
 		});
@@ -325,14 +325,14 @@ describe('CheckboxItem', function () {
 		it('should have icon to the right of text when default', async function () {
 			const checkboxItem = await Page.components.checkboxDefault;
 
-			expectOrdering(checkboxItem.value, checkboxItem.icon);
+			await expectOrdering(checkboxItem.value, checkboxItem.icon);
 		});
 
 		it('should have two inlined checkboxes positioned inlined', async function () {
 			const checkboxItem1 = await Page.components.checkboxInline.self;
 			const checkboxItem2 = await Page.components.checkboxInlineAfter.self;
 
-			expectInline(checkboxItem1, checkboxItem2);
+			await expectInline(checkboxItem1, checkboxItem2);
 		});
 	});
 });

--- a/tests/ui/specs/DatePicker/DatePicker-specs.js
+++ b/tests/ui/specs/DatePicker/DatePicker-specs.js
@@ -46,7 +46,7 @@ describe('DatePicker', function () {
 					});
 
 					const month = new Date(await datePicker.valueText).getMonth();
-					expectOpen(await datePicker);
+					await expectOpen(await datePicker);
 					expect(await datePicker.month.isFocused()).to.be.true();
 					expect(month).to.be.within(0, 11);
 				});
@@ -56,10 +56,10 @@ describe('DatePicker', function () {
 						Page.spotlightSelect();
 					});
 
-					expectOpen(await datePicker);
+					await expectOpen(await datePicker);
 					expect(await datePicker.month.isFocused()).to.be.true();
 					await Page.spotlightSelect();
-					expectClosed(await datePicker);
+					await expectClosed(await datePicker);
 				});
 
 				it('should focus title when 5-way right from last picker - [GT-24986]', async function () {
@@ -67,7 +67,7 @@ describe('DatePicker', function () {
 						Page.spotlightSelect();
 					});
 
-					expectOpen(await datePicker);
+					await expectOpen(await datePicker);
 					expect(await datePicker.month.isFocused()).to.be.true();
 					await Page.spotlightRight();
 					await Page.spotlightRight();
@@ -81,7 +81,7 @@ describe('DatePicker', function () {
 					});
 
 					const {month} = await extractValues(datePicker);
-					expectOpen(await datePicker);
+					await expectOpen(await datePicker);
 					expect(await datePicker.month.isFocused()).to.be.true();
 					await Page.waitTransitionEnd(3000, undefined, () => {
 						Page.spotlightUp();
@@ -97,7 +97,7 @@ describe('DatePicker', function () {
 					});
 
 					const {month} = await extractValues(datePicker);
-					expectOpen(await datePicker);
+					await expectOpen(await datePicker);
 					expect(await datePicker.month.isFocused()).to.be.true();
 					await Page.waitTransitionEnd(3000, undefined, () => {
 						Page.spotlightDown();
@@ -114,7 +114,7 @@ describe('DatePicker', function () {
 
 					const {day, month, year} = await extractValues(datePicker);
 					const numDays = daysInMonth({month, year});
-					expectOpen(await datePicker);
+					await expectOpen(await datePicker);
 					await Page.spotlightRight();
 					expect(await datePicker.day.isFocused()).to.be.true();
 					await Page.waitTransitionEnd(3000, undefined, () => {
@@ -132,7 +132,7 @@ describe('DatePicker', function () {
 
 					const {day, month, year} = await extractValues(datePicker);
 					const numDays = daysInMonth({month, year});
-					expectOpen(await datePicker);
+					await expectOpen(await datePicker);
 					await Page.spotlightRight();
 					expect(await datePicker.day.isFocused()).to.be.true();
 					await Page.waitTransitionEnd(3000, undefined, () => {
@@ -149,7 +149,7 @@ describe('DatePicker', function () {
 					});
 
 					const {year} = await extractValues(datePicker);
-					expectOpen(await datePicker);
+					await expectOpen(await datePicker);
 					await Page.spotlightRight();
 					await Page.spotlightRight();
 					expect(await datePicker.year.isFocused()).to.be.true();
@@ -167,7 +167,7 @@ describe('DatePicker', function () {
 					});
 
 					const {year} = await extractValues(datePicker);
-					expectOpen(await datePicker);
+					await expectOpen(await datePicker);
 					await Page.spotlightRight();
 					await Page.spotlightRight();
 					expect(await datePicker.year.isFocused()).to.be.true();
@@ -185,18 +185,18 @@ describe('DatePicker', function () {
 					await Page.waitTransitionEnd(3000, undefined, () => {
 						datePicker.title.click();
 					});
-					expectOpen(await datePicker);
+					await expectOpen(await datePicker);
 				});
 
 				it('should close on title click when open', async function () {
 					await Page.waitTransitionEnd(3000, undefined, () => {
 						datePicker.title.click();
 					});
-					expectOpen(await datePicker);
+					await expectOpen(await datePicker);
 					await Page.waitTransitionEnd(3000, undefined, () => {
 						datePicker.title.click();
 					});
-					expectClosed(await datePicker);
+					await expectClosed(await datePicker);
 				});
 
 				it('should select item', async function () {
@@ -212,7 +212,7 @@ describe('DatePicker', function () {
 						datePicker.title.click();
 					});
 					const {month} = await extractValues(datePicker);
-					expectOpen(await datePicker);
+					await expectOpen(await datePicker);
 					await Page.waitTransitionEnd(3000, undefined, () => {
 						datePicker.incrementer(datePicker.month).click();
 					});
@@ -397,7 +397,7 @@ describe('DatePicker', function () {
 
 			it('should not have labeled pickers', async function () {
 				await datePicker.title.click();
-				expectNoLabels(datePicker);
+				await expectNoLabels(datePicker);
 			});
 		});
 

--- a/tests/ui/specs/DatePicker/DatePicker-specs.js
+++ b/tests/ui/specs/DatePicker/DatePicker-specs.js
@@ -27,7 +27,7 @@ describe('DatePicker', function () {
 			});
 
 			it('should have month-day-year order', async function () {
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -41,7 +41,7 @@ describe('DatePicker', function () {
 
 			describe('5-way', function () {
 				it('should open, spot first item on select, and update value to current date', async function () {
-					await Page.waitTransitionEnd(3000, undefined, () => {
+					await Page.waitTransitionEnd(2000, undefined, () => {
 						Page.spotlightSelect();
 					});
 
@@ -52,7 +52,7 @@ describe('DatePicker', function () {
 				});
 
 				it('should close when pressing select', async function () {
-					await Page.waitTransitionEnd(3000, undefined, () => {
+					await Page.waitTransitionEnd(2000, undefined, () => {
 						Page.spotlightSelect();
 					});
 
@@ -63,7 +63,7 @@ describe('DatePicker', function () {
 				});
 
 				it('should focus title when 5-way right from last picker - [GT-24986]', async function () {
-					await Page.waitTransitionEnd(3000, undefined, () => {
+					await Page.waitTransitionEnd(2000, undefined, () => {
 						Page.spotlightSelect();
 					});
 
@@ -76,14 +76,14 @@ describe('DatePicker', function () {
 				});
 
 				it('should increase the month when incrementing the picker', async function () {
-					await Page.waitTransitionEnd(3000, undefined, () => {
+					await Page.waitTransitionEnd(2000, undefined, () => {
 						Page.spotlightSelect();
 					});
 
 					const {month} = await extractValues(datePicker);
 					expectOpen(await datePicker);
 					expect(await datePicker.month.isFocused()).to.be.true();
-					await Page.waitTransitionEnd(3000, undefined, () => {
+					await Page.waitTransitionEnd(2000, undefined, () => {
 						Page.spotlightUp();
 					});
 					const {month: value} = await extractValues(datePicker);
@@ -92,14 +92,14 @@ describe('DatePicker', function () {
 				});
 
 				it('should decrease the month when decrementing the picker - [GT-21247]', async function () {
-					await Page.waitTransitionEnd(3000, undefined, () => {
+					await Page.waitTransitionEnd(2000, undefined, () => {
 						Page.spotlightSelect();
 					});
 
 					const {month} = await extractValues(datePicker);
 					expectOpen(await datePicker);
 					expect(await datePicker.month.isFocused()).to.be.true();
-					await Page.waitTransitionEnd(3000, undefined, () => {
+					await Page.waitTransitionEnd(2000, undefined, () => {
 						Page.spotlightDown();
 					});
 					const {month: value} = await extractValues(datePicker);
@@ -108,7 +108,7 @@ describe('DatePicker', function () {
 				});
 
 				it('should increase the day when incrementing the picker - [GT-21247]', async function () {
-					await Page.waitTransitionEnd(3000, undefined, () => {
+					await Page.waitTransitionEnd(2000, undefined, () => {
 						Page.spotlightSelect();
 					});
 
@@ -117,7 +117,7 @@ describe('DatePicker', function () {
 					expectOpen(await datePicker);
 					await Page.spotlightRight();
 					expect(await datePicker.day.isFocused()).to.be.true();
-					await Page.waitTransitionEnd(3000, undefined, () => {
+					await Page.waitTransitionEnd(2000, undefined, () => {
 						Page.spotlightUp();
 					});
 					const {day: value} = await extractValues(datePicker);
@@ -126,7 +126,7 @@ describe('DatePicker', function () {
 				});
 
 				it('should decrease the day when decrementing the picker', async function () {
-					await Page.waitTransitionEnd(3000, undefined, () => {
+					await Page.waitTransitionEnd(2000, undefined, () => {
 						Page.spotlightSelect();
 					});
 
@@ -135,7 +135,7 @@ describe('DatePicker', function () {
 					expectOpen(await datePicker);
 					await Page.spotlightRight();
 					expect(await datePicker.day.isFocused()).to.be.true();
-					await Page.waitTransitionEnd(3000, undefined, () => {
+					await Page.waitTransitionEnd(2000, undefined, () => {
 						Page.spotlightDown();
 					});
 					const {day: value} = await extractValues(datePicker);
@@ -144,7 +144,7 @@ describe('DatePicker', function () {
 				});
 
 				it('should increase the year when incrementing the picker - [GT-21247]', async function () {
-					await Page.waitTransitionEnd(3000, undefined, () => {
+					await Page.waitTransitionEnd(2000, undefined, () => {
 						Page.spotlightSelect();
 					});
 
@@ -153,7 +153,7 @@ describe('DatePicker', function () {
 					await Page.spotlightRight();
 					await Page.spotlightRight();
 					expect(await datePicker.year.isFocused()).to.be.true();
-					await Page.waitTransitionEnd(3000, undefined, () => {
+					await Page.waitTransitionEnd(2000, undefined, () => {
 						Page.spotlightUp();
 					});
 					const {year: value} = await extractValues(datePicker);
@@ -162,7 +162,7 @@ describe('DatePicker', function () {
 				});
 
 				it('should decrease the year when decrementing the picker', async function () {
-					await Page.waitTransitionEnd(3000, undefined, () => {
+					await Page.waitTransitionEnd(2000, undefined, () => {
 						Page.spotlightSelect();
 					});
 
@@ -171,7 +171,7 @@ describe('DatePicker', function () {
 					await Page.spotlightRight();
 					await Page.spotlightRight();
 					expect(await datePicker.year.isFocused()).to.be.true();
-					await Page.waitTransitionEnd(3000, undefined, () => {
+					await Page.waitTransitionEnd(2000, undefined, () => {
 						Page.spotlightDown();
 					});
 					const {year: value} = await extractValues(datePicker);
@@ -182,25 +182,25 @@ describe('DatePicker', function () {
 
 			describe('pointer', function () {
 				it('should open on title click when closed', async function () {
-					await Page.waitTransitionEnd(3000, undefined, () => {
+					await Page.waitTransitionEnd(2000, undefined, () => {
 						datePicker.title.click();
 					});
 					expectOpen(await datePicker);
 				});
 
 				it('should close on title click when open', async function () {
-					await Page.waitTransitionEnd(3000, undefined, () => {
+					await Page.waitTransitionEnd(2000, undefined, () => {
 						datePicker.title.click();
 					});
 					expectOpen(await datePicker);
-					await Page.waitTransitionEnd(3000, undefined, () => {
+					await Page.waitTransitionEnd(2000, undefined, () => {
 						datePicker.title.click();
 					});
 					expectClosed(await datePicker);
 				});
 
 				it('should select item', async function () {
-					await Page.waitTransitionEnd(3000, undefined, () => {
+					await Page.waitTransitionEnd(2000, undefined, () => {
 						datePicker.title.click();
 					});
 					await datePicker.month.click();
@@ -208,12 +208,12 @@ describe('DatePicker', function () {
 				});
 
 				it('should increase the month when incrementing the picker', async function () {
-					await Page.waitTransitionEnd(3000, undefined, () => {
+					await Page.waitTransitionEnd(2000, undefined, () => {
 						datePicker.title.click();
 					});
 					const {month} = await extractValues(datePicker);
 					expectOpen(await datePicker);
-					await Page.waitTransitionEnd(3000, undefined, () => {
+					await Page.waitTransitionEnd(2000, undefined, () => {
 						datePicker.incrementer(datePicker.month).click();
 					});
 					const {month: value} = await extractValues(datePicker);
@@ -222,12 +222,12 @@ describe('DatePicker', function () {
 				});
 
 				it('should decrease the month when decrementing the picker', async function () {
-					await Page.waitTransitionEnd(3000, undefined, () => {
+					await Page.waitTransitionEnd(2000, undefined, () => {
 						datePicker.title.click();
 					});
 					const {month} = await extractValues(datePicker);
 					await expectOpen(datePicker);
-					await Page.waitTransitionEnd(3000, undefined, () => {
+					await Page.waitTransitionEnd(2000, undefined, () => {
 						datePicker.decrementer(datePicker.month).click();
 					});
 					const {month: value} = await extractValues(datePicker);
@@ -236,13 +236,13 @@ describe('DatePicker', function () {
 				});
 
 				it('should increase the day when incrementing the picker', async function () {
-					await Page.waitTransitionEnd(3000, undefined, () => {
+					await Page.waitTransitionEnd(2000, undefined, () => {
 						datePicker.title.click();
 					});
 					const {day, month, year} = await extractValues(datePicker);
 					const numDays = daysInMonth({month, year});
 					await expectOpen(datePicker);
-					await Page.waitTransitionEnd(3000, undefined, () => {
+					await Page.waitTransitionEnd(2000, undefined, () => {
 						datePicker.incrementer(datePicker.day).click();
 					});
 					const {day: value} = await extractValues(datePicker);
@@ -251,13 +251,13 @@ describe('DatePicker', function () {
 				});
 
 				it('should decrease the day when decrementing the picker', async function () {
-					await Page.waitTransitionEnd(3000, undefined, () => {
+					await Page.waitTransitionEnd(2000, undefined, () => {
 						datePicker.title.click();
 					});
 					const {day, month, year} = await extractValues(datePicker);
 					const numDays = daysInMonth({month, year});
 					await expectOpen(datePicker);
-					await Page.waitTransitionEnd(3000, undefined, () => {
+					await Page.waitTransitionEnd(2000, undefined, () => {
 						datePicker.decrementer(datePicker.day).click();
 					});
 					const {day: value} = await extractValues(datePicker);
@@ -266,12 +266,12 @@ describe('DatePicker', function () {
 				});
 
 				it('should increase the year when incrementing the picker', async function () {
-					await Page.waitTransitionEnd(3000, undefined, () => {
+					await Page.waitTransitionEnd(2000, undefined, () => {
 						datePicker.title.click();
 					});
 					const {year} = await extractValues(datePicker);
 					await expectOpen(datePicker);
-					await Page.waitTransitionEnd(3000, undefined, () => {
+					await Page.waitTransitionEnd(2000, undefined, () => {
 						datePicker.incrementer(datePicker.year).click();
 					});
 					const {year: value} = await extractValues(datePicker);
@@ -280,12 +280,12 @@ describe('DatePicker', function () {
 				});
 
 				it('should decrease the year when decrementing the picker', async function () {
-					await Page.waitTransitionEnd(3000, undefined, () => {
+					await Page.waitTransitionEnd(2000, undefined, () => {
 						datePicker.title.click();
 					});
 					const {year} = await extractValues(datePicker);
 					await expectOpen(datePicker);
-					await Page.waitTransitionEnd(3000, undefined, () => {
+					await Page.waitTransitionEnd(2000, undefined, () => {
 						datePicker.decrementer(datePicker.year).click();
 					});
 					const {year: value} = await extractValues(datePicker);
@@ -314,7 +314,7 @@ describe('DatePicker', function () {
 			describe('5-way', function () {
 				it('should close when pressing select', async function () {
 					await datePicker.focus();
-					await Page.waitTransitionEnd(3000, undefined, () => {
+					await Page.waitTransitionEnd(2000, undefined, () => {
 						Page.spotlightSelect();
 					});
 
@@ -325,18 +325,18 @@ describe('DatePicker', function () {
 
 			describe('pointer', function () {
 				it('should close on title click when open - [GT-21246]', async function () {
-					await Page.waitTransitionEnd(3000, undefined, () => {
+					await Page.waitTransitionEnd(2000, undefined, () => {
 						datePicker.title.click();
 					});
 					await expectClosed(datePicker);
 				});
 
 				it('should open on title click when closed', async function () {
-					await Page.waitTransitionEnd(3000, undefined, () => {
+					await Page.waitTransitionEnd(2000, undefined, () => {
 						datePicker.title.click();
 					});
 					await expectClosed(datePicker);
-					await Page.waitTransitionEnd(3000, undefined, () => {
+					await Page.waitTransitionEnd(2000, undefined, () => {
 						datePicker.title.click();
 					});
 					await expectOpen(datePicker);
@@ -365,7 +365,7 @@ describe('DatePicker', function () {
 			describe('5-way', function () {
 				it('should not update on select', async function () {
 					await datePicker.focus();
-					await Page.waitTransitionEnd(3000, undefined, () => {
+					await Page.waitTransitionEnd(2000, undefined, () => {
 						Page.spotlightSelect();
 					});
 
@@ -379,7 +379,7 @@ describe('DatePicker', function () {
 
 			describe('pointer', function () {
 				it('should not update on title click', async function () {
-					await Page.waitTransitionEnd(3000, undefined, () => {
+					await Page.waitTransitionEnd(2000, undefined, () => {
 						datePicker.title.click();
 					});
 					const {day, month, year} = await extractValues(datePicker);
@@ -484,7 +484,7 @@ describe('DatePicker', function () {
 		});
 
 		it('should focus rightmost picker (day) when selected', async function () {
-			await Page.waitTransitionEnd(3000, undefined, () => {
+			await Page.waitTransitionEnd(2000, undefined, () => {
 				Page.spotlightSelect();
 			});
 
@@ -493,7 +493,7 @@ describe('DatePicker', function () {
 		});
 
 		it('should have day-month-year order', async function () {
-			await Page.waitTransitionEnd(3000, undefined, () => {
+			await Page.waitTransitionEnd(2000, undefined, () => {
 				Page.spotlightSelect();
 			});
 
@@ -506,7 +506,7 @@ describe('DatePicker', function () {
 		});
 
 		it('should focus title when 5-way left from last picker - [GT-25238]', async function () {
-			await Page.waitTransitionEnd(3000, undefined, () => {
+			await Page.waitTransitionEnd(2000, undefined, () => {
 				Page.spotlightSelect();
 			});
 

--- a/tests/ui/specs/DatePicker/DatePicker-specs.js
+++ b/tests/ui/specs/DatePicker/DatePicker-specs.js
@@ -27,7 +27,7 @@ describe('DatePicker', function () {
 			});
 
 			it('should have month-day-year order', async function () {
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -41,7 +41,7 @@ describe('DatePicker', function () {
 
 			describe('5-way', function () {
 				it('should open, spot first item on select, and update value to current date', async function () {
-					await Page.waitTransitionEnd(2000, undefined, () => {
+					await Page.waitTransitionEnd(3000, undefined, () => {
 						Page.spotlightSelect();
 					});
 
@@ -52,7 +52,7 @@ describe('DatePicker', function () {
 				});
 
 				it('should close when pressing select', async function () {
-					await Page.waitTransitionEnd(2000, undefined, () => {
+					await Page.waitTransitionEnd(3000, undefined, () => {
 						Page.spotlightSelect();
 					});
 
@@ -63,7 +63,7 @@ describe('DatePicker', function () {
 				});
 
 				it('should focus title when 5-way right from last picker - [GT-24986]', async function () {
-					await Page.waitTransitionEnd(2000, undefined, () => {
+					await Page.waitTransitionEnd(3000, undefined, () => {
 						Page.spotlightSelect();
 					});
 
@@ -76,14 +76,14 @@ describe('DatePicker', function () {
 				});
 
 				it('should increase the month when incrementing the picker', async function () {
-					await Page.waitTransitionEnd(2000, undefined, () => {
+					await Page.waitTransitionEnd(3000, undefined, () => {
 						Page.spotlightSelect();
 					});
 
 					const {month} = await extractValues(datePicker);
 					expectOpen(await datePicker);
 					expect(await datePicker.month.isFocused()).to.be.true();
-					await Page.waitTransitionEnd(2000, undefined, () => {
+					await Page.waitTransitionEnd(3000, undefined, () => {
 						Page.spotlightUp();
 					});
 					const {month: value} = await extractValues(datePicker);
@@ -92,14 +92,14 @@ describe('DatePicker', function () {
 				});
 
 				it('should decrease the month when decrementing the picker - [GT-21247]', async function () {
-					await Page.waitTransitionEnd(2000, undefined, () => {
+					await Page.waitTransitionEnd(3000, undefined, () => {
 						Page.spotlightSelect();
 					});
 
 					const {month} = await extractValues(datePicker);
 					expectOpen(await datePicker);
 					expect(await datePicker.month.isFocused()).to.be.true();
-					await Page.waitTransitionEnd(2000, undefined, () => {
+					await Page.waitTransitionEnd(3000, undefined, () => {
 						Page.spotlightDown();
 					});
 					const {month: value} = await extractValues(datePicker);
@@ -108,7 +108,7 @@ describe('DatePicker', function () {
 				});
 
 				it('should increase the day when incrementing the picker - [GT-21247]', async function () {
-					await Page.waitTransitionEnd(2000, undefined, () => {
+					await Page.waitTransitionEnd(3000, undefined, () => {
 						Page.spotlightSelect();
 					});
 
@@ -117,7 +117,7 @@ describe('DatePicker', function () {
 					expectOpen(await datePicker);
 					await Page.spotlightRight();
 					expect(await datePicker.day.isFocused()).to.be.true();
-					await Page.waitTransitionEnd(2000, undefined, () => {
+					await Page.waitTransitionEnd(3000, undefined, () => {
 						Page.spotlightUp();
 					});
 					const {day: value} = await extractValues(datePicker);
@@ -126,7 +126,7 @@ describe('DatePicker', function () {
 				});
 
 				it('should decrease the day when decrementing the picker', async function () {
-					await Page.waitTransitionEnd(2000, undefined, () => {
+					await Page.waitTransitionEnd(3000, undefined, () => {
 						Page.spotlightSelect();
 					});
 
@@ -135,7 +135,7 @@ describe('DatePicker', function () {
 					expectOpen(await datePicker);
 					await Page.spotlightRight();
 					expect(await datePicker.day.isFocused()).to.be.true();
-					await Page.waitTransitionEnd(2000, undefined, () => {
+					await Page.waitTransitionEnd(3000, undefined, () => {
 						Page.spotlightDown();
 					});
 					const {day: value} = await extractValues(datePicker);
@@ -144,7 +144,7 @@ describe('DatePicker', function () {
 				});
 
 				it('should increase the year when incrementing the picker - [GT-21247]', async function () {
-					await Page.waitTransitionEnd(2000, undefined, () => {
+					await Page.waitTransitionEnd(3000, undefined, () => {
 						Page.spotlightSelect();
 					});
 
@@ -153,7 +153,7 @@ describe('DatePicker', function () {
 					await Page.spotlightRight();
 					await Page.spotlightRight();
 					expect(await datePicker.year.isFocused()).to.be.true();
-					await Page.waitTransitionEnd(2000, undefined, () => {
+					await Page.waitTransitionEnd(3000, undefined, () => {
 						Page.spotlightUp();
 					});
 					const {year: value} = await extractValues(datePicker);
@@ -162,7 +162,7 @@ describe('DatePicker', function () {
 				});
 
 				it('should decrease the year when decrementing the picker', async function () {
-					await Page.waitTransitionEnd(2000, undefined, () => {
+					await Page.waitTransitionEnd(3000, undefined, () => {
 						Page.spotlightSelect();
 					});
 
@@ -171,7 +171,7 @@ describe('DatePicker', function () {
 					await Page.spotlightRight();
 					await Page.spotlightRight();
 					expect(await datePicker.year.isFocused()).to.be.true();
-					await Page.waitTransitionEnd(2000, undefined, () => {
+					await Page.waitTransitionEnd(3000, undefined, () => {
 						Page.spotlightDown();
 					});
 					const {year: value} = await extractValues(datePicker);
@@ -182,25 +182,25 @@ describe('DatePicker', function () {
 
 			describe('pointer', function () {
 				it('should open on title click when closed', async function () {
-					await Page.waitTransitionEnd(2000, undefined, () => {
+					await Page.waitTransitionEnd(3000, undefined, () => {
 						datePicker.title.click();
 					});
 					expectOpen(await datePicker);
 				});
 
 				it('should close on title click when open', async function () {
-					await Page.waitTransitionEnd(2000, undefined, () => {
+					await Page.waitTransitionEnd(3000, undefined, () => {
 						datePicker.title.click();
 					});
 					expectOpen(await datePicker);
-					await Page.waitTransitionEnd(2000, undefined, () => {
+					await Page.waitTransitionEnd(3000, undefined, () => {
 						datePicker.title.click();
 					});
 					expectClosed(await datePicker);
 				});
 
 				it('should select item', async function () {
-					await Page.waitTransitionEnd(2000, undefined, () => {
+					await Page.waitTransitionEnd(3000, undefined, () => {
 						datePicker.title.click();
 					});
 					await datePicker.month.click();
@@ -208,12 +208,12 @@ describe('DatePicker', function () {
 				});
 
 				it('should increase the month when incrementing the picker', async function () {
-					await Page.waitTransitionEnd(2000, undefined, () => {
+					await Page.waitTransitionEnd(3000, undefined, () => {
 						datePicker.title.click();
 					});
 					const {month} = await extractValues(datePicker);
 					expectOpen(await datePicker);
-					await Page.waitTransitionEnd(2000, undefined, () => {
+					await Page.waitTransitionEnd(3000, undefined, () => {
 						datePicker.incrementer(datePicker.month).click();
 					});
 					const {month: value} = await extractValues(datePicker);
@@ -222,12 +222,12 @@ describe('DatePicker', function () {
 				});
 
 				it('should decrease the month when decrementing the picker', async function () {
-					await Page.waitTransitionEnd(2000, undefined, () => {
+					await Page.waitTransitionEnd(3000, undefined, () => {
 						datePicker.title.click();
 					});
 					const {month} = await extractValues(datePicker);
 					await expectOpen(datePicker);
-					await Page.waitTransitionEnd(2000, undefined, () => {
+					await Page.waitTransitionEnd(3000, undefined, () => {
 						datePicker.decrementer(datePicker.month).click();
 					});
 					const {month: value} = await extractValues(datePicker);
@@ -236,13 +236,13 @@ describe('DatePicker', function () {
 				});
 
 				it('should increase the day when incrementing the picker', async function () {
-					await Page.waitTransitionEnd(2000, undefined, () => {
+					await Page.waitTransitionEnd(3000, undefined, () => {
 						datePicker.title.click();
 					});
 					const {day, month, year} = await extractValues(datePicker);
 					const numDays = daysInMonth({month, year});
 					await expectOpen(datePicker);
-					await Page.waitTransitionEnd(2000, undefined, () => {
+					await Page.waitTransitionEnd(3000, undefined, () => {
 						datePicker.incrementer(datePicker.day).click();
 					});
 					const {day: value} = await extractValues(datePicker);
@@ -251,13 +251,13 @@ describe('DatePicker', function () {
 				});
 
 				it('should decrease the day when decrementing the picker', async function () {
-					await Page.waitTransitionEnd(2000, undefined, () => {
+					await Page.waitTransitionEnd(3000, undefined, () => {
 						datePicker.title.click();
 					});
 					const {day, month, year} = await extractValues(datePicker);
 					const numDays = daysInMonth({month, year});
 					await expectOpen(datePicker);
-					await Page.waitTransitionEnd(2000, undefined, () => {
+					await Page.waitTransitionEnd(3000, undefined, () => {
 						datePicker.decrementer(datePicker.day).click();
 					});
 					const {day: value} = await extractValues(datePicker);
@@ -266,12 +266,12 @@ describe('DatePicker', function () {
 				});
 
 				it('should increase the year when incrementing the picker', async function () {
-					await Page.waitTransitionEnd(2000, undefined, () => {
+					await Page.waitTransitionEnd(3000, undefined, () => {
 						datePicker.title.click();
 					});
 					const {year} = await extractValues(datePicker);
 					await expectOpen(datePicker);
-					await Page.waitTransitionEnd(2000, undefined, () => {
+					await Page.waitTransitionEnd(3000, undefined, () => {
 						datePicker.incrementer(datePicker.year).click();
 					});
 					const {year: value} = await extractValues(datePicker);
@@ -280,12 +280,12 @@ describe('DatePicker', function () {
 				});
 
 				it('should decrease the year when decrementing the picker', async function () {
-					await Page.waitTransitionEnd(2000, undefined, () => {
+					await Page.waitTransitionEnd(3000, undefined, () => {
 						datePicker.title.click();
 					});
 					const {year} = await extractValues(datePicker);
 					await expectOpen(datePicker);
-					await Page.waitTransitionEnd(2000, undefined, () => {
+					await Page.waitTransitionEnd(3000, undefined, () => {
 						datePicker.decrementer(datePicker.year).click();
 					});
 					const {year: value} = await extractValues(datePicker);
@@ -314,7 +314,7 @@ describe('DatePicker', function () {
 			describe('5-way', function () {
 				it('should close when pressing select', async function () {
 					await datePicker.focus();
-					await Page.waitTransitionEnd(2000, undefined, () => {
+					await Page.waitTransitionEnd(3000, undefined, () => {
 						Page.spotlightSelect();
 					});
 
@@ -325,18 +325,18 @@ describe('DatePicker', function () {
 
 			describe('pointer', function () {
 				it('should close on title click when open - [GT-21246]', async function () {
-					await Page.waitTransitionEnd(2000, undefined, () => {
+					await Page.waitTransitionEnd(3000, undefined, () => {
 						datePicker.title.click();
 					});
 					await expectClosed(datePicker);
 				});
 
 				it('should open on title click when closed', async function () {
-					await Page.waitTransitionEnd(2000, undefined, () => {
+					await Page.waitTransitionEnd(3000, undefined, () => {
 						datePicker.title.click();
 					});
 					await expectClosed(datePicker);
-					await Page.waitTransitionEnd(2000, undefined, () => {
+					await Page.waitTransitionEnd(3000, undefined, () => {
 						datePicker.title.click();
 					});
 					await expectOpen(datePicker);
@@ -365,7 +365,7 @@ describe('DatePicker', function () {
 			describe('5-way', function () {
 				it('should not update on select', async function () {
 					await datePicker.focus();
-					await Page.waitTransitionEnd(2000, undefined, () => {
+					await Page.waitTransitionEnd(3000, undefined, () => {
 						Page.spotlightSelect();
 					});
 
@@ -379,7 +379,7 @@ describe('DatePicker', function () {
 
 			describe('pointer', function () {
 				it('should not update on title click', async function () {
-					await Page.waitTransitionEnd(2000, undefined, () => {
+					await Page.waitTransitionEnd(3000, undefined, () => {
 						datePicker.title.click();
 					});
 					const {day, month, year} = await extractValues(datePicker);
@@ -484,7 +484,7 @@ describe('DatePicker', function () {
 		});
 
 		it('should focus rightmost picker (day) when selected', async function () {
-			await Page.waitTransitionEnd(2000, undefined, () => {
+			await Page.waitTransitionEnd(3000, undefined, () => {
 				Page.spotlightSelect();
 			});
 
@@ -493,7 +493,7 @@ describe('DatePicker', function () {
 		});
 
 		it('should have day-month-year order', async function () {
-			await Page.waitTransitionEnd(2000, undefined, () => {
+			await Page.waitTransitionEnd(3000, undefined, () => {
 				Page.spotlightSelect();
 			});
 
@@ -506,7 +506,7 @@ describe('DatePicker', function () {
 		});
 
 		it('should focus title when 5-way left from last picker - [GT-25238]', async function () {
-			await Page.waitTransitionEnd(2000, undefined, () => {
+			await Page.waitTransitionEnd(3000, undefined, () => {
 				Page.spotlightSelect();
 			});
 

--- a/tests/ui/specs/ExpandableInput/ExpandableInput-specs.js
+++ b/tests/ui/specs/ExpandableInput/ExpandableInput-specs.js
@@ -676,7 +676,7 @@ describe('ExpandableInput', function () {
 			});
 
 			it('should have title icon be on the right side title label', async function () {
-				await expectOrdering(await expandable.titleIcon, await expandable.titleTextMarquee);
+				expectOrdering(await expandable.titleIcon, await expandable.titleTextMarquee);
 			});
 		});
 
@@ -684,7 +684,7 @@ describe('ExpandableInput', function () {
 			const expandable = Page.components.iconBeforeAfter;
 
 			it('should have beforeIcon positioned on the right side of the afterIcon', async function () {
-				await expectOrdering(await expandable.iconAfter, await expandable.iconBefore);
+				expectOrdering(await expandable.iconAfter, await expandable.iconBefore);
 			});
 		});
 	});

--- a/tests/ui/specs/ExpandableInput/ExpandableInput-specs.js
+++ b/tests/ui/specs/ExpandableInput/ExpandableInput-specs.js
@@ -162,13 +162,17 @@ describe('ExpandableInput', function () {
 					await Page.waitTransitionEnd(3000, undefined, () => {
 						expandable.title.click();
 					});
-					expandable.input.click();
+					await expandable.input.click();
 					await expectOpen(expandable);
 				});
 
 				it('should close on two title clicks', async function () {
-					expandable.title.click();
-					expandable.title.click();
+					await Page.waitTransitionEnd(3000, undefined, () => {
+						expandable.title.click();
+					});
+					await Page.waitTransitionEnd(3000, undefined, () => {
+						expandable.title.click();
+					});
 					await expectClosed(expandable);
 				});
 
@@ -278,13 +282,17 @@ describe('ExpandableInput', function () {
 					await Page.waitTransitionEnd(3000, undefined, () => {
 						expandable.title.click();
 					});
-					expandable.input.click();
+					await expandable.input.click();
 					await expectOpen(expandable);
 				});
 
 				it('should close on two title clicks', async function () {
-					expandable.title.click();
-					expandable.title.click();
+					await Page.waitTransitionEnd(3000, undefined, () => {
+						expandable.title.click();
+					});
+					await Page.waitTransitionEnd(3000, undefined, () => {
+						expandable.title.click();
+					});
 					await expectClosed(expandable);
 				});
 			});
@@ -353,7 +361,9 @@ describe('ExpandableInput', function () {
 					await Page.waitTransitionEnd(3000, undefined, () => {
 						expandable.title.click();
 					});
-					expandable.title.click();
+					await Page.waitTransitionEnd(3000, undefined, () => {
+						expandable.title.click();
+					});
 					await expectOpen(expandable);
 				});
 			});
@@ -609,7 +619,7 @@ describe('ExpandableInput', function () {
 
 			describe('5-way', function () {
 				it('should be spottable', async function () {
-					expandable.focus();
+					await expandable.focus();
 					// Page.spotlightDown();
 					expect(await expandable.title.isFocused()).to.be.true();
 				});
@@ -622,7 +632,7 @@ describe('ExpandableInput', function () {
 
 			describe('pointer', function () {
 				it('should stay closed on title click', async function () {
-					expandable.title.click();
+					await expandable.title.click();
 					browser.pause(500);
 					await expectClosed(expandable);
 				});
@@ -666,7 +676,7 @@ describe('ExpandableInput', function () {
 			});
 
 			it('should have title icon be on the right side title label', async function () {
-				expectOrdering(await expandable.titleIcon, await expandable.titleTextMarquee);
+				await expectOrdering(await expandable.titleIcon, await expandable.titleTextMarquee);
 			});
 		});
 
@@ -674,7 +684,7 @@ describe('ExpandableInput', function () {
 			const expandable = Page.components.iconBeforeAfter;
 
 			it('should have beforeIcon positioned on the right side of the afterIcon', async function () {
-				expectOrdering(await expandable.iconAfter, await expandable.iconBefore);
+				await expectOrdering(await expandable.iconAfter, await expandable.iconBefore);
 			});
 		});
 	});

--- a/tests/ui/specs/ExpandableItem/ExpandableItem-specs.js
+++ b/tests/ui/specs/ExpandableItem/ExpandableItem-specs.js
@@ -22,7 +22,7 @@ describe('ExpandableItem', function () {
 
 		describe('5-way', function () {
 			it('should open and spot expanded item on select - [GT-21494]', async function () {
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -32,13 +32,13 @@ describe('ExpandableItem', function () {
 
 			it('should close when pressing select on label', async function () {
 				await Page.spotlightUp();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
 				await expectOpen(expandableItem);
 				await Page.spotlightUp();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -47,7 +47,7 @@ describe('ExpandableItem', function () {
 
 			it('should allow 5-way navigation beyond the last item', async function () {
 				await expandableItem.focus();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -60,18 +60,18 @@ describe('ExpandableItem', function () {
 
 		describe('pointer', function () {
 			it('should open on title click when closed', async function () {
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					expandableItem.title.click();
 				});
 				await expectOpen(expandableItem);
 			});
 
 			it('should close on title click when open', async function () {
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					expandableItem.title.click();
 				});
 				await expectOpen(expandableItem);
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					expandableItem.title.click();
 				});
 				await expectClosed(expandableItem);
@@ -97,7 +97,7 @@ describe('ExpandableItem', function () {
 		describe('5-way', function () {
 			it('should close when pressing select', async function () {
 				await expandableItem.focus();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -108,18 +108,18 @@ describe('ExpandableItem', function () {
 
 		describe('pointer', function () {
 			it('should close on title click when open', async function () {
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					expandableItem.title.click();
 				});
 				await expectClosed(expandableItem);
 			});
 
 			it('should open on title click when closed', async function () {
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					expandableItem.title.click();
 				});
 				await expectClosed(expandableItem);
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					expandableItem.title.click();
 				});
 				await expectOpen(expandableItem);
@@ -132,13 +132,13 @@ describe('ExpandableItem', function () {
 
 		it('should close when 5-way focus returns to title', async function () {
 			await expandableItem.focus();
-			await Page.waitTransitionEnd(2000, undefined, () => {
+			await Page.waitTransitionEnd(3000, undefined, () => {
 				Page.spotlightSelect();
 			});
 
 			await expectOpen(expandableItem);
 			expect(await expandableItem.item.isFocused()).to.be.true();
-			await Page.waitTransitionEnd(2000, undefined, () => {
+			await Page.waitTransitionEnd(3000, undefined, () => {
 				Page.spotlightUp();
 			});
 			await expectClosed(expandableItem);
@@ -150,7 +150,7 @@ describe('ExpandableItem', function () {
 
 		it('should not allow 5-way navigation beyond the last item', async function () {
 			await expandableItem.focus();
-			await Page.waitTransitionEnd(2000, undefined, () => {
+			await Page.waitTransitionEnd(3000, undefined, () => {
 				Page.spotlightSelect();
 			});
 

--- a/tests/ui/specs/ExpandableItem/ExpandableItem-specs.js
+++ b/tests/ui/specs/ExpandableItem/ExpandableItem-specs.js
@@ -276,7 +276,7 @@ describe('ExpandableItem', function () {
 
 		describe('pointer', function () {
 			it('should not open when clicked', async function () {
-				expandableItem.title.click();
+				await expandableItem.title.click();
 				await expectClosed(expandableItem);
 			});
 		});

--- a/tests/ui/specs/ExpandableItem/ExpandableItem-specs.js
+++ b/tests/ui/specs/ExpandableItem/ExpandableItem-specs.js
@@ -22,7 +22,7 @@ describe('ExpandableItem', function () {
 
 		describe('5-way', function () {
 			it('should open and spot expanded item on select - [GT-21494]', async function () {
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -32,13 +32,13 @@ describe('ExpandableItem', function () {
 
 			it('should close when pressing select on label', async function () {
 				await Page.spotlightUp();
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
 				await expectOpen(expandableItem);
 				await Page.spotlightUp();
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -47,7 +47,7 @@ describe('ExpandableItem', function () {
 
 			it('should allow 5-way navigation beyond the last item', async function () {
 				await expandableItem.focus();
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -60,18 +60,18 @@ describe('ExpandableItem', function () {
 
 		describe('pointer', function () {
 			it('should open on title click when closed', async function () {
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					expandableItem.title.click();
 				});
 				await expectOpen(expandableItem);
 			});
 
 			it('should close on title click when open', async function () {
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					expandableItem.title.click();
 				});
 				await expectOpen(expandableItem);
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					expandableItem.title.click();
 				});
 				await expectClosed(expandableItem);
@@ -97,7 +97,7 @@ describe('ExpandableItem', function () {
 		describe('5-way', function () {
 			it('should close when pressing select', async function () {
 				await expandableItem.focus();
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -108,18 +108,18 @@ describe('ExpandableItem', function () {
 
 		describe('pointer', function () {
 			it('should close on title click when open', async function () {
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					expandableItem.title.click();
 				});
 				await expectClosed(expandableItem);
 			});
 
 			it('should open on title click when closed', async function () {
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					expandableItem.title.click();
 				});
 				await expectClosed(expandableItem);
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					expandableItem.title.click();
 				});
 				await expectOpen(expandableItem);
@@ -132,13 +132,13 @@ describe('ExpandableItem', function () {
 
 		it('should close when 5-way focus returns to title', async function () {
 			await expandableItem.focus();
-			await Page.waitTransitionEnd(3000, undefined, () => {
+			await Page.waitTransitionEnd(2000, undefined, () => {
 				Page.spotlightSelect();
 			});
 
 			await expectOpen(expandableItem);
 			expect(await expandableItem.item.isFocused()).to.be.true();
-			await Page.waitTransitionEnd(3000, undefined, () => {
+			await Page.waitTransitionEnd(2000, undefined, () => {
 				Page.spotlightUp();
 			});
 			await expectClosed(expandableItem);
@@ -150,7 +150,7 @@ describe('ExpandableItem', function () {
 
 		it('should not allow 5-way navigation beyond the last item', async function () {
 			await expandableItem.focus();
-			await Page.waitTransitionEnd(3000, undefined, () => {
+			await Page.waitTransitionEnd(2000, undefined, () => {
 				Page.spotlightSelect();
 			});
 

--- a/tests/ui/specs/ExpandableList/ExpandableList-specs.js
+++ b/tests/ui/specs/ExpandableList/ExpandableList-specs.js
@@ -27,7 +27,7 @@ describe('ExpandableList', function () {
 
 		describe('5-way', function () {
 			it('should open and spot first item on select', async function () {
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -36,12 +36,12 @@ describe('ExpandableList', function () {
 			});
 
 			it('should close when moving up to header', async function () {
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
 				expect(await expandable.isOpen()).to.be.true();
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightUp();
 				});
 				expect(await expandable.isOpen()).to.be.false();
@@ -49,7 +49,7 @@ describe('ExpandableList', function () {
 			});
 
 			it('should not allow 5-way exit from bottom', async function () {
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -62,7 +62,7 @@ describe('ExpandableList', function () {
 			});
 
 			it('should select item when pressing select', async function () {
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -71,7 +71,7 @@ describe('ExpandableList', function () {
 			});
 
 			it('should update value text on select', async function () {
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -81,7 +81,7 @@ describe('ExpandableList', function () {
 			});
 
 			it('should not unselect item', async function () {
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -91,7 +91,7 @@ describe('ExpandableList', function () {
 			});
 
 			it('should only allow one selected item', async function () {
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -105,25 +105,25 @@ describe('ExpandableList', function () {
 
 		describe('pointer', function () {
 			it('should open on title click when closed', async function () {
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					expandable.title.click();
 				});
 				await expectOpen(expandable);
 			});
 
 			it('should close on title click when open', async function () {
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					expandable.title.click();
 				});
 				expect(await expandable.isOpen()).to.be.true();
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					expandable.title.click();
 				});
 				expect(await expandable.isOpen()).to.be.false();
 			});
 
 			it('should select item', async function () {
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					expandable.title.click();
 				});
 				await expandable.item(0).click();
@@ -131,18 +131,18 @@ describe('ExpandableList', function () {
 			});
 
 			it('should update value text', async function () {
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					expandable.title.click();
 				});
 				await expandable.item(0).click();
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					expandable.title.click();
 				});
 				expect(await expandable.valueText).to.equal('option1');
 			});
 
 			it('should not unselect item', async function () {
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					expandable.title.click();
 				});
 				await expandable.item(0).click();
@@ -151,7 +151,7 @@ describe('ExpandableList', function () {
 			});
 
 			it('should only allow one selected item', async function () {
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					expandable.title.click();
 				});
 				await expandable.item(0).click();
@@ -178,7 +178,7 @@ describe('ExpandableList', function () {
 		describe('5-way', function () {
 			it('should open and spot first item on select', async function () {
 				await expandable.focus();
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -188,7 +188,7 @@ describe('ExpandableList', function () {
 
 			it('should select item when pressing select', async function () {
 				await expandable.focus();
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -198,7 +198,7 @@ describe('ExpandableList', function () {
 
 			it('should update value text on select', async function () {
 				await expandable.focus();
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -209,7 +209,7 @@ describe('ExpandableList', function () {
 
 			it('should allow unselecting item', async function () {
 				await expandable.focus();
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -220,7 +220,7 @@ describe('ExpandableList', function () {
 
 			it('should allow multiple selected items', async function () {
 				await expandable.focus();
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -233,7 +233,7 @@ describe('ExpandableList', function () {
 
 			it('should combine value text with multi-select', async function () {
 				await expandable.focus();
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -248,25 +248,25 @@ describe('ExpandableList', function () {
 
 		describe('pointer', function () {
 			it('should open on title click when closed', async function () {
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					expandable.title.click();
 				});
 				await expectOpen(expandable);
 			});
 
 			it('should close on title click when open', async function () {
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					expandable.title.click();
 				});
 				expect(await expandable.isOpen()).to.be.true();
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					expandable.title.click();
 				});
 				expect(await expandable.isOpen()).to.be.false();
 			});
 
 			it('should select item', async function () {
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					expandable.title.click();
 				});
 				expandable.item(0).click();
@@ -274,27 +274,27 @@ describe('ExpandableList', function () {
 			});
 
 			it('should update value text', async function () {
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					expandable.title.click();
 				});
 				expandable.item(0).click();
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					expandable.title.click();
 				});
 				expect(await expandable.valueText).to.equal('option1');
 			});
 
 			it('should allow unselecting item', async function () {
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					expandable.title.click();
 				});
 				expandable.item(0).click();
 				expandable.item(0).click();
-				expect(await expandable.item(0).$(expandable.selectedClass).isExisting()).to.be.false();
+				expect(await expandable.item(0).getAttribute('aria-checked')).to.equal('false');
 			});
 
 			it('should allow multiple selected items', async function () {
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					expandable.title.click();
 				});
 				expandable.item(0).click();
@@ -321,7 +321,7 @@ describe('ExpandableList', function () {
 		describe('5-way', function () {
 			it('should open and spot first item on select', async function () {
 				await expandable.focus();
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -331,7 +331,7 @@ describe('ExpandableList', function () {
 
 			it('should select item when pressing select', async function () {
 				await expandable.focus();
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -341,7 +341,7 @@ describe('ExpandableList', function () {
 
 			it('should update value text on select', async function () {
 				await expandable.focus();
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -352,7 +352,7 @@ describe('ExpandableList', function () {
 
 			it('should allow unselecting item', async function () {
 				await expandable.focus();
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -363,7 +363,7 @@ describe('ExpandableList', function () {
 
 			it('should reset none text if nothing selected', async function () {
 				await expandable.focus();
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -375,7 +375,7 @@ describe('ExpandableList', function () {
 
 			it('should not allow multiple selected items', async function () {
 				await expandable.focus();
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -389,25 +389,25 @@ describe('ExpandableList', function () {
 
 		describe('pointer', function () {
 			it('should open on title click when closed', async function () {
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					expandable.title.click();
 				});
 				await expectOpen(expandable);
 			});
 
 			it('should close on title click when open', async function () {
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					expandable.title.click();
 				});
 				expect(await expandable.isOpen()).to.be.true();
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					expandable.title.click();
 				});
 				expect(await expandable.isOpen()).to.be.false();
 			});
 
 			it('should select item', async function () {
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					expandable.title.click();
 				});
 				await expandable.item(0).click();
@@ -415,18 +415,18 @@ describe('ExpandableList', function () {
 			});
 
 			it('should update value text', async function () {
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					expandable.title.click();
 				});
 				await expandable.item(0).click();
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					expandable.title.click();
 				});
 				expect(await expandable.valueText).to.equal('option1');
 			});
 
 			it('should unselect item', async function () {
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					expandable.title.click();
 				});
 				await expandable.item(0).click();
@@ -435,7 +435,7 @@ describe('ExpandableList', function () {
 			});
 
 			it('should only allow one selected item', async function () {
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					expandable.title.click();
 				});
 				await expandable.item(0).click();
@@ -454,7 +454,7 @@ describe('ExpandableList', function () {
 		describe('5-way', function () {
 			it('should allow 5-way out when open', async function () {
 				await expandable.focus();
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -480,7 +480,7 @@ describe('ExpandableList', function () {
 		describe('5-way', function () {
 			it('should open and spot first item on select', async function () {
 				await expandable.focus();
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -490,7 +490,7 @@ describe('ExpandableList', function () {
 
 			it('should not close when navigating up to title', async function () {
 				await expandable.focus();
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -513,7 +513,7 @@ describe('ExpandableList', function () {
 		describe('5-way', function () {
 			it('should close on select', async function () {
 				await expandable.focus();
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -524,7 +524,7 @@ describe('ExpandableList', function () {
 			it('should close when navigating up to title', async function () {
 				await expandable.focus();
 				await Page.spotlightDown();
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					Page.spotlightUp();
 				});
 				expect(await expandable.isOpen()).to.be.false();
@@ -535,7 +535,7 @@ describe('ExpandableList', function () {
 
 		describe('pointer', function () {
 			it('should close on title click', async function () {
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					expandable.title.click();
 				});
 				expect(await expandable.isOpen()).to.be.false();
@@ -543,11 +543,11 @@ describe('ExpandableList', function () {
 			});
 
 			it('should open on title click when closed', async function () {
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					expandable.title.click();
 				});
 				expect(await expandable.isOpen()).to.be.false();
-				await Page.waitTransitionEnd(3000, undefined, () => {
+				await Page.waitTransitionEnd(2000, undefined, () => {
 					expandable.title.click();
 				});
 				expect(await expandable.isOpen()).to.be.true();
@@ -600,10 +600,10 @@ describe('ExpandableList', function () {
 
 	describe('general pointer operation', function () {
 		it('should not close other expandable when opening', async function () {
-			await Page.waitTransitionEnd(3000, undefined, () => {
+			await Page.waitTransitionEnd(2000, undefined, () => {
 				Page.components.radioSelect.title.click();
 			});
-			await Page.waitTransitionEnd(3000, undefined, () => {
+			await Page.waitTransitionEnd(2000, undefined, () => {
 				Page.components.multiSelect.title.click();
 			});
 			expect(await Page.components.radioSelect.isOpen()).to.be.true();

--- a/tests/ui/specs/ExpandableList/ExpandableList-specs.js
+++ b/tests/ui/specs/ExpandableList/ExpandableList-specs.js
@@ -269,7 +269,7 @@ describe('ExpandableList', function () {
 				await Page.waitTransitionEnd(2000, undefined, () => {
 					expandable.title.click();
 				});
-				expandable.item(0).click();
+				await expandable.item(0).click();
 				expect(await expandable.item(0).$(expandable.selectedClass).isExisting()).to.be.true();
 			});
 
@@ -277,7 +277,7 @@ describe('ExpandableList', function () {
 				await Page.waitTransitionEnd(2000, undefined, () => {
 					expandable.title.click();
 				});
-				expandable.item(0).click();
+				await expandable.item(0).click();
 				await Page.waitTransitionEnd(2000, undefined, () => {
 					expandable.title.click();
 				});
@@ -288,17 +288,17 @@ describe('ExpandableList', function () {
 				await Page.waitTransitionEnd(2000, undefined, () => {
 					expandable.title.click();
 				});
-				expandable.item(0).click();
-				expandable.item(0).click();
-				expect(await expandable.item(0).getAttribute('aria-checked')).to.equal('false');
+				await expandable.item(0).click();
+				await expandable.item(0).click();
+				expect(await expandable.item(0).$(expandable.selectedClass).isExisting()).to.be.false();
 			});
 
 			it('should allow multiple selected items', async function () {
 				await Page.waitTransitionEnd(2000, undefined, () => {
 					expandable.title.click();
 				});
-				expandable.item(0).click();
-				expandable.item(1).click();
+				await expandable.item(0).click();
+				await expandable.item(1).click();
 				expect(await expandable.item(0).$(expandable.selectedClass).isExisting()).to.be.true();
 				expect(await expandable.item(1).$(expandable.selectedClass).isExisting()).to.be.true();
 			});

--- a/tests/ui/specs/ExpandableList/ExpandableList-specs.js
+++ b/tests/ui/specs/ExpandableList/ExpandableList-specs.js
@@ -27,7 +27,7 @@ describe('ExpandableList', function () {
 
 		describe('5-way', function () {
 			it('should open and spot first item on select', async function () {
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -36,12 +36,12 @@ describe('ExpandableList', function () {
 			});
 
 			it('should close when moving up to header', async function () {
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
 				expect(await expandable.isOpen()).to.be.true();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					Page.spotlightUp();
 				});
 				expect(await expandable.isOpen()).to.be.false();
@@ -49,7 +49,7 @@ describe('ExpandableList', function () {
 			});
 
 			it('should not allow 5-way exit from bottom', async function () {
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -62,7 +62,7 @@ describe('ExpandableList', function () {
 			});
 
 			it('should select item when pressing select', async function () {
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -71,7 +71,7 @@ describe('ExpandableList', function () {
 			});
 
 			it('should update value text on select', async function () {
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -81,7 +81,7 @@ describe('ExpandableList', function () {
 			});
 
 			it('should not unselect item', async function () {
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -91,7 +91,7 @@ describe('ExpandableList', function () {
 			});
 
 			it('should only allow one selected item', async function () {
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -105,25 +105,25 @@ describe('ExpandableList', function () {
 
 		describe('pointer', function () {
 			it('should open on title click when closed', async function () {
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					expandable.title.click();
 				});
 				await expectOpen(expandable);
 			});
 
 			it('should close on title click when open', async function () {
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					expandable.title.click();
 				});
 				expect(await expandable.isOpen()).to.be.true();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					expandable.title.click();
 				});
 				expect(await expandable.isOpen()).to.be.false();
 			});
 
 			it('should select item', async function () {
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					expandable.title.click();
 				});
 				await expandable.item(0).click();
@@ -131,18 +131,18 @@ describe('ExpandableList', function () {
 			});
 
 			it('should update value text', async function () {
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					expandable.title.click();
 				});
 				await expandable.item(0).click();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					expandable.title.click();
 				});
 				expect(await expandable.valueText).to.equal('option1');
 			});
 
 			it('should not unselect item', async function () {
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					expandable.title.click();
 				});
 				await expandable.item(0).click();
@@ -151,7 +151,7 @@ describe('ExpandableList', function () {
 			});
 
 			it('should only allow one selected item', async function () {
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					expandable.title.click();
 				});
 				await expandable.item(0).click();
@@ -178,7 +178,7 @@ describe('ExpandableList', function () {
 		describe('5-way', function () {
 			it('should open and spot first item on select', async function () {
 				await expandable.focus();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -188,7 +188,7 @@ describe('ExpandableList', function () {
 
 			it('should select item when pressing select', async function () {
 				await expandable.focus();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -198,7 +198,7 @@ describe('ExpandableList', function () {
 
 			it('should update value text on select', async function () {
 				await expandable.focus();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -209,7 +209,7 @@ describe('ExpandableList', function () {
 
 			it('should allow unselecting item', async function () {
 				await expandable.focus();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -220,7 +220,7 @@ describe('ExpandableList', function () {
 
 			it('should allow multiple selected items', async function () {
 				await expandable.focus();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -233,7 +233,7 @@ describe('ExpandableList', function () {
 
 			it('should combine value text with multi-select', async function () {
 				await expandable.focus();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -248,25 +248,25 @@ describe('ExpandableList', function () {
 
 		describe('pointer', function () {
 			it('should open on title click when closed', async function () {
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					expandable.title.click();
 				});
 				await expectOpen(expandable);
 			});
 
 			it('should close on title click when open', async function () {
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					expandable.title.click();
 				});
 				expect(await expandable.isOpen()).to.be.true();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					expandable.title.click();
 				});
 				expect(await expandable.isOpen()).to.be.false();
 			});
 
 			it('should select item', async function () {
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					expandable.title.click();
 				});
 				await expandable.item(0).click();
@@ -274,18 +274,18 @@ describe('ExpandableList', function () {
 			});
 
 			it('should update value text', async function () {
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					expandable.title.click();
 				});
 				await expandable.item(0).click();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					expandable.title.click();
 				});
 				expect(await expandable.valueText).to.equal('option1');
 			});
 
 			it('should allow unselecting item', async function () {
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					expandable.title.click();
 				});
 				await expandable.item(0).click();
@@ -294,7 +294,7 @@ describe('ExpandableList', function () {
 			});
 
 			it('should allow multiple selected items', async function () {
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					expandable.title.click();
 				});
 				await expandable.item(0).click();
@@ -321,7 +321,7 @@ describe('ExpandableList', function () {
 		describe('5-way', function () {
 			it('should open and spot first item on select', async function () {
 				await expandable.focus();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -331,7 +331,7 @@ describe('ExpandableList', function () {
 
 			it('should select item when pressing select', async function () {
 				await expandable.focus();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -341,7 +341,7 @@ describe('ExpandableList', function () {
 
 			it('should update value text on select', async function () {
 				await expandable.focus();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -352,7 +352,7 @@ describe('ExpandableList', function () {
 
 			it('should allow unselecting item', async function () {
 				await expandable.focus();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -363,7 +363,7 @@ describe('ExpandableList', function () {
 
 			it('should reset none text if nothing selected', async function () {
 				await expandable.focus();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -375,7 +375,7 @@ describe('ExpandableList', function () {
 
 			it('should not allow multiple selected items', async function () {
 				await expandable.focus();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -389,25 +389,25 @@ describe('ExpandableList', function () {
 
 		describe('pointer', function () {
 			it('should open on title click when closed', async function () {
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					expandable.title.click();
 				});
 				await expectOpen(expandable);
 			});
 
 			it('should close on title click when open', async function () {
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					expandable.title.click();
 				});
 				expect(await expandable.isOpen()).to.be.true();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					expandable.title.click();
 				});
 				expect(await expandable.isOpen()).to.be.false();
 			});
 
 			it('should select item', async function () {
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					expandable.title.click();
 				});
 				await expandable.item(0).click();
@@ -415,18 +415,18 @@ describe('ExpandableList', function () {
 			});
 
 			it('should update value text', async function () {
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					expandable.title.click();
 				});
 				await expandable.item(0).click();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					expandable.title.click();
 				});
 				expect(await expandable.valueText).to.equal('option1');
 			});
 
 			it('should unselect item', async function () {
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					expandable.title.click();
 				});
 				await expandable.item(0).click();
@@ -435,7 +435,7 @@ describe('ExpandableList', function () {
 			});
 
 			it('should only allow one selected item', async function () {
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					expandable.title.click();
 				});
 				await expandable.item(0).click();
@@ -454,7 +454,7 @@ describe('ExpandableList', function () {
 		describe('5-way', function () {
 			it('should allow 5-way out when open', async function () {
 				await expandable.focus();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -480,7 +480,7 @@ describe('ExpandableList', function () {
 		describe('5-way', function () {
 			it('should open and spot first item on select', async function () {
 				await expandable.focus();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -490,7 +490,7 @@ describe('ExpandableList', function () {
 
 			it('should not close when navigating up to title', async function () {
 				await expandable.focus();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -513,7 +513,7 @@ describe('ExpandableList', function () {
 		describe('5-way', function () {
 			it('should close on select', async function () {
 				await expandable.focus();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					Page.spotlightSelect();
 				});
 
@@ -524,7 +524,7 @@ describe('ExpandableList', function () {
 			it('should close when navigating up to title', async function () {
 				await expandable.focus();
 				await Page.spotlightDown();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					Page.spotlightUp();
 				});
 				expect(await expandable.isOpen()).to.be.false();
@@ -535,7 +535,7 @@ describe('ExpandableList', function () {
 
 		describe('pointer', function () {
 			it('should close on title click', async function () {
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					expandable.title.click();
 				});
 				expect(await expandable.isOpen()).to.be.false();
@@ -543,11 +543,11 @@ describe('ExpandableList', function () {
 			});
 
 			it('should open on title click when closed', async function () {
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					expandable.title.click();
 				});
 				expect(await expandable.isOpen()).to.be.false();
-				await Page.waitTransitionEnd(2000, undefined, () => {
+				await Page.waitTransitionEnd(3000, undefined, () => {
 					expandable.title.click();
 				});
 				expect(await expandable.isOpen()).to.be.true();
@@ -600,10 +600,10 @@ describe('ExpandableList', function () {
 
 	describe('general pointer operation', function () {
 		it('should not close other expandable when opening', async function () {
-			await Page.waitTransitionEnd(2000, undefined, () => {
+			await Page.waitTransitionEnd(3000, undefined, () => {
 				Page.components.radioSelect.title.click();
 			});
-			await Page.waitTransitionEnd(2000, undefined, () => {
+			await Page.waitTransitionEnd(3000, undefined, () => {
 				Page.components.multiSelect.title.click();
 			});
 			expect(await Page.components.radioSelect.isOpen()).to.be.true();

--- a/tests/ui/specs/TimePicker/TimePicker-specs.js
+++ b/tests/ui/specs/TimePicker/TimePicker-specs.js
@@ -22,7 +22,7 @@ describe('TimePicker', function () {
 			});
 
 			it('should be initially closed', async function () {
-				timePicker.self.waitForExist(500);
+				await timePicker.self.waitForExist(500);
 				await expectClosed(timePicker);
 			});
 
@@ -329,7 +329,7 @@ describe('TimePicker', function () {
 			const timePicker = Page.components.timePickerDefaultOpenWithNoneText;
 
 			it('should be initially open', async function () {
-				timePicker.self.waitForExist(500);
+				await timePicker.self.waitForExist(500);
 				await expectOpen(timePicker);
 			});
 
@@ -371,7 +371,7 @@ describe('TimePicker', function () {
 			const timePicker = Page.components.timePickerDefaultOpenWithDefaultValue;
 
 			it('should be initially open', async function () {
-				timePicker.self.waitForExist(500);
+				await timePicker.self.waitForExist(500);
 				await expectOpen(timePicker);
 			});
 
@@ -419,7 +419,7 @@ describe('TimePicker', function () {
 
 			it('should not have labeled pickers', async function () {
 				timePicker.title.click();
-				expectNoLabels(timePicker);
+				await expectNoLabels(timePicker);
 			});
 		});
 
@@ -427,7 +427,7 @@ describe('TimePicker', function () {
 			const timePicker = Page.components.timePickerDisabledWithNoneText;
 
 			it('should be initially closed', async function () {
-				timePicker.self.waitForExist(500);
+				await timePicker.self.waitForExist(500);
 				await expectClosed(timePicker);
 			});
 
@@ -442,7 +442,7 @@ describe('TimePicker', function () {
 					expect(await timePicker.title.isFocused()).to.be.true();
 				});
 				it('should not open when selected', async function () {
-					timePicker.focus();
+					await timePicker.focus();
 					await Page.spotlightSelect();
 					// it should never open, but wait and then check to be sure
 					browser.pause(500);
@@ -464,7 +464,7 @@ describe('TimePicker', function () {
 			const timePicker = Page.components.timePickerDisabledWithDefaultValue;
 
 			it('should be initially closed', async function () {
-				timePicker.self.waitForExist(500);
+				await timePicker.self.waitForExist(500);
 				await expectClosed(timePicker);
 			});
 
@@ -477,7 +477,7 @@ describe('TimePicker', function () {
 			const timePicker = Page.components.timePickerDisabledOpenWithNoneText;
 
 			it('should be initially closed', async function () {
-				timePicker.self.waitForExist(500);
+				await timePicker.self.waitForExist(500);
 				await expectClosed(timePicker);
 			});
 


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Stanca Pop stanca.pop@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There was an ui test that kept failing for ActivityPanels. Sometimes, when clicking on button4 there is a double transition and it takes you directly to the last panel. 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
We adjusted the test so that it passes, but the issue with the double transition is not fixed. Currently there are 2 tests that fail, for ExpandableItem ("Can't call $ on element with selector "#expandable1" because element wasn't found") and ExpandableList ("waitUntil condition timed out after 10000ms"), but this kind of errors will be handled in a different issue.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRO-6999

### Comments
