### PR TITLE
WRO-8219: TimePicker: Fix isomorphic build error

### DIFF
--- a/TimePicker/TimePickerBase.js
+++ b/TimePicker/TimePickerBase.js
@@ -304,7 +304,7 @@ const TimePickerBase = kind({
 
 	computed: {
 		hasMeridiem: ({order}) => order.indexOf('a') >= 0,
-		meridiemPickerWidth: ({meridiem, meridiems}) => meridiems && meridiems[meridiem].length * 2
+		meridiemPickerWidth: ({meridiem, meridiems}) => meridiems?.[meridiem].length * 2
 	},
 
 	render: ({

--- a/TimePicker/TimePickerBase.js
+++ b/TimePicker/TimePickerBase.js
@@ -304,7 +304,7 @@ const TimePickerBase = kind({
 
 	computed: {
 		hasMeridiem: ({order}) => order.indexOf('a') >= 0,
-		meridiemPickerWidth: ({meridiem, meridiems}) => meridiems[meridiem].length * 2
+		meridiemPickerWidth: ({meridiem, meridiems}) => meridiems && meridiems[meridiem].length * 2
 	},
 
 	render: ({


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`qa-scroller` failed to build when `enact pack --isomorphic`.


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
When `TimePicker` is at the first view, the isomorphic build is failed.
There were accessing a property of `undefined` from TimePickerBase. So I've added a guard code.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-8219

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)