### PR TITLE
WRO-13490: Modify jsdocs comments for @link tag

### DIFF
--- a/BodyText/BodyText.js
+++ b/BodyText/BodyText.js
@@ -28,7 +28,7 @@ const MarqueeBodyText = MarqueeDecorator(UiBodyText);
  * A simple text block component.
  *
  * This component is most often not used directly but may be composed within another component as it
- * is within [BodyText]{@link moonstone/BodyText.BodyText}.
+ * is within {@link moonstone/BodyText.BodyText|BodyText}.
  *
  * @class BodyTextBase
  * @memberof moonstone/BodyText
@@ -44,7 +44,7 @@ const BodyTextBase = kind({
 		 * Centers the contents.
 		 *
 		 * Applies the `centered` CSS class which can be customized by
-		 * [theming]{@link /docs/developer-guide/theming/}.
+		 * {@link /docs/developer-guide/theming/|theming}.
 		 *
 		 * @type {Boolean}
 		 * @public
@@ -125,7 +125,7 @@ const BodyTextBase = kind({
 });
 
 /**
- * Applies Moonstone specific behaviors to [BodyText]{@link moonstone/BodyText.BodyTextBase}.
+ * Applies Moonstone specific behaviors to {@link moonstone/BodyText.BodyTextBase|BodyText}.
  *
  * @hoc
  * @memberof moonstone/BodyText

--- a/Button/Button.js
+++ b/Button/Button.js
@@ -31,7 +31,7 @@ const Icon = Skinnable(IconBase);
  * A button component.
  *
  * This component is most often not used directly but may be composed within another component as it
- * is within [Button]{@link moonstone/Button.Button}.
+ * is within {@link moonstone/Button.Button|Button}.
  *
  * @class ButtonBase
  * @memberof moonstone/Button
@@ -155,7 +155,7 @@ const ButtonBase = kind({
 
 
 /**
- * Applies Moonstone specific behaviors to [Button]{@link moonstone/Button.ButtonBase} components.
+ * Applies Moonstone specific behaviors to {@link moonstone/Button.ButtonBase|Button} components.
  *
  * @hoc
  * @memberof moonstone/Button

--- a/Checkbox/Checkbox.js
+++ b/Checkbox/Checkbox.js
@@ -21,7 +21,7 @@ import css from './Checkbox.module.less';
  * A checkbox component, ready to use in Moonstone applications.
  *
  * `Checkbox` may be used independently to represent a toggleable state but is more commonly used as
- * part of [CheckboxItem]{@link moonstone/CheckboxItem}.
+ * part of {@link moonstone/CheckboxItem|CheckboxItem}.
  *
  * Usage:
  * ```

--- a/CheckboxItem/CheckboxItem.js
+++ b/CheckboxItem/CheckboxItem.js
@@ -23,7 +23,7 @@ import componentCss from './CheckboxItem.module.less';
  * An item with a checkbox component, ready to use in Moonstone applications.
  *
  * `CheckboxItem` may be used to allow the user to select a single option or used as part of a
- * [Group]{@link ui/Group} when multiple [selections]{@link ui/Group.Group.select} are possible.
+ * {@link ui/Group|Group} when multiple {@link ui/Group.Group.select|selections} are possible.
  *
  * Usage:
  * ```

--- a/ContextualPopupDecorator/ContextualPopup.js
+++ b/ContextualPopupDecorator/ContextualPopup.js
@@ -50,9 +50,9 @@ const ContextualPopupRoot = Skinnable(
 
 /**
  * A popup component used by
- * [ContextualPopupDecorator]{@link moonstone/ContextualPopupDecorator.ContextualPopupDecorator} to
+ * {@link moonstone/ContextualPopupDecorator.ContextualPopupDecorator|ContextualPopupDecorator} to
  * wrap its
- * [popupComponent]{@link moonstone/ContextualPopupDecorator.ContextualPopupDecorator.popupComponent}.
+ * {@link moonstone/ContextualPopupDecorator.ContextualPopupDecorator.popupComponent|popupComponent}.
  *
  * `ContextualPopup` is usually not used directly but is made available for unique application use
  * cases.

--- a/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -81,7 +81,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 		static propTypes = /** @lends moonstone/ContextualPopupDecorator.ContextualPopupDecorator.prototype */ {
 			/**
 			 * The component rendered within the
-			 * [ContextualPopup]{@link moonstone/ContextualPopupDecorator.ContextualPopup}.
+			 * {@link moonstone/ContextualPopupDecorator.ContextualPopup|ContextualPopup}.
 			 *
 			 * @type {Component}
 			 * @required
@@ -149,7 +149,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 
 			/**
 			 * CSS class name to pass to the
-			 * [ContextualPopup]{@link moonstone/ContextualPopupDecorator.ContextualPopup}.
+			 * {@link moonstone/ContextualPopupDecorator.ContextualPopup|ContextualPopup}.
 			 *
 			 * This is commonly used to set width and height of the popup.
 			 *
@@ -187,8 +187,8 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 			rtl: PropTypes.bool,
 
 			/**
-			 * Registers the ContextualPopupDecorator component with an [ApiDecorator]
-			 * {@link core/internal/ApiDecorator.ApiDecorator}.
+			 * Registers the ContextualPopupDecorator component with an
+			 * {@link core/internal/ApiDecorator.ApiDecorator|ApiDecorator}.
 			 *
 			 * @type {Function}
 			 * @private
@@ -208,7 +208,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 			 * The current skin for this component.
 			 *
 			 * When `noSkin` is set on the config object, `skin` will only be applied to the
-			 * [ContextualPopup]{@link moonstone/ContextualPopupDecorator.ContextualPopup} and not
+			 * {@link moonstone/ContextualPopupDecorator.ContextualPopup|ContextualPopup} and not
 			 * to the popup's activator component.
 			 *
 			 * @see {@link moonstone/Skinnable.Skinnable.skin}
@@ -640,7 +640,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 
 /**
  * Adds support for positioning a
- * [ContextualPopup]{@link moonstone/ContextualPopupDecorator.ContextualPopup} relative to the
+ * {@link moonstone/ContextualPopupDecorator.ContextualPopup|ContextualPopup} relative to the
  * wrapped component.
  *
  * `ContextualPopupDecorator` may be used to show additional settings or actions rendered within a

--- a/DatePicker/DatePicker.js
+++ b/DatePicker/DatePicker.js
@@ -102,7 +102,7 @@ const dateTimeConfig = {
  *
  * `DatePicker` may be used to select the year, month, and day. It uses a standard `Date` object for
  * its `value` which can be shared as the `value` for a
- * [TimePicker]{@link moonstone/TimePicker.TimePicker} to select both a date and time.
+ * {@link moonstone/TimePicker.TimePicker|TimePicker} to select both a date and time.
  *
  * By default, `DatePicker` maintains the state of its `value` property. Supply the
  * `defaultValue` property to control its initial value. If you wish to directly control updates

--- a/DatePicker/DatePickerBase.js
+++ b/DatePicker/DatePickerBase.js
@@ -13,7 +13,7 @@ import internalCss from '../internal/DateComponentPicker/DateComponentPicker.mod
  * A date selection component.
  *
  * This component is most often not used directly but may be composed within another component as it
- * is within [DatePicker]{@link moonstone/DatePicker.DatePicker}.
+ * is within {@link moonstone/DatePicker.DatePicker|DatePicker}.
  *
  * @class DatePickerBase
  * @memberof moonstone/DatePicker

--- a/DayPicker/DayPicker.js
+++ b/DayPicker/DayPicker.js
@@ -31,7 +31,7 @@ import Skinnable from '../Skinnable';
  * A day of the week selection component.
  *
  * This component is most often not used directly but may be composed within another component as it
- * is within [DayPicker]{@link moonstone/DayPicker.DayPicker}.
+ * is within {@link moonstone/DayPicker.DayPicker|DayPicker}.
  *
  * @class DayPickerBase
  * @memberof moonstone/DayPicker
@@ -131,10 +131,10 @@ const DayPickerDecorator = compose(
  * An expandable day of the week selection component, ready to use in Moonstone applications.
  *
  * `DayPicker` may be used to select one or more days of the week. Upon selection, it will display
- * the short names of each day selected or customizable strings when selecting [every
- * day]{@link moonstone/DayPicker.DayPicker.everyDayText}), [every
- * weekday]{@link moonstone/DayPicker.DayPicker.everyWeekdayText}, and [every weekend
- * day]{@link moonstone/DayPicker.DayPicker.everyWeekendText}.
+ * the short names of each day selected or customizable strings when selecting
+ * {@link moonstone/DayPicker.DayPicker.everyDayText|every day},
+ * {@link moonstone/DayPicker.DayPicker.everyWeekdayText|every weekday}, and
+ * {@link moonstone/DayPicker.DayPicker.everyWeekendText|every weekend day}.
  *
  * By default, `DayPicker` maintains the state of its `selected` property. Supply the
  * `defaultSelected` property to control its initial value. If you wish to directly control updates

--- a/DaySelector/DaySelector.js
+++ b/DaySelector/DaySelector.js
@@ -32,7 +32,7 @@ import componentCss from './DaySelector.module.less';
  * A Moonstone styled inline day of the week selection component.
  *
  * This component is most often not used directly but may be composed within another component as it
- * is within [DaySelector]{@link moonstone/DaySelector.DaySelector}.
+ * is within {@link moonstone/DaySelector.DaySelector|DaySelector}.
  *
  * @class DaySelectorBase
  * @memberof moonstone/DaySelector

--- a/DaySelector/DaySelectorCheckbox.js
+++ b/DaySelector/DaySelectorCheckbox.js
@@ -9,7 +9,7 @@ import css from './DaySelectorCheckbox.module.less';
 /**
  * A component that represents the selected state of a day within a
  * {@link moonstone/DaySelector.DaySelector}. It has built-in spotlight support and is intended for
- * use in a specialized [Item]{@link moonstone/Item} that does not visually respond to focus, so
+ * use in a specialized {@link moonstone/Item|Item} that does not visually respond to focus, so
  * this can show focus instead.
  *
  * @class DaySelectorCheckbox

--- a/DaySelector/DaySelectorDecorator.js
+++ b/DaySelector/DaySelectorDecorator.js
@@ -71,7 +71,7 @@ function getLocaleState (dayNameLength, locale) {
 
 /**
  * Applies Moonstone specific behaviors to
- * [DaySelector]{@link moonstone/DaySelector.DaySelectorBase}.
+ * {@link moonstone/DaySelector.DaySelectorBase|DaySelector}.
  *
  * @hoc
  * @memberof moonstone/DaySelector

--- a/DaySelector/DaySelectorItem.js
+++ b/DaySelector/DaySelectorItem.js
@@ -8,7 +8,7 @@ import DaySelectorCheckbox from './DaySelectorCheckbox';
 import css from './DaySelectorItem.module.less';
 
 /**
- * An extension of [Item]{@link moonstone/Item.Item} that can be toggled between two states via its
+ * An extension of {@link moonstone/Item.Item|Item} that can be toggled between two states via its
  * `selected` prop.
  *
  * By default, `DaySelectorItem` maintains the state of its `selected` property. Supply the

--- a/Dialog/Dialog.js
+++ b/Dialog/Dialog.js
@@ -24,7 +24,7 @@ const MarqueeH2 = MarqueeDecorator('h2');
  * A modal dialog component.
  *
  * This component is most often not used directly but may be composed within another component as it
- * is within [Dialog]{@link moonstone/Dialog.Dialog}.
+ * is within {@link moonstone/Dialog.Dialog|Dialog}.
  *
  * @class DialogBase
  * @memberof moonstone/Dialog
@@ -217,7 +217,7 @@ const DialogBase = kind({
  *
  * `Dialog` may be used to interrupt a workflow to receive feedback from the user. The dialong
  * consists of a title, a subtitle, a message, and an area for additional
- * [buttons]{@link moonstone/Dialog.Dialog.buttons}.
+ * {@link moonstone/Dialog.Dialog.buttons|buttons}.
  *
  * Usage:
  * ```

--- a/Dropdown/Dropdown.js
+++ b/Dropdown/Dropdown.js
@@ -278,7 +278,7 @@ const DropdownBase = kind({
 
 /**
  * Applies Moonstone specific behaviors and functionality to
- * [DropdownBase]{@link moonstone/Dropdown.DropdownBase}.
+ * {@link moonstone/Dropdown.DropdownBase|DropdownBase}.
  *
  * @hoc
  * @memberof moonstone/Dropdown

--- a/EditableIntegerPicker/EditableIntegerPicker.js
+++ b/EditableIntegerPicker/EditableIntegerPicker.js
@@ -53,7 +53,7 @@ const EditableIntegerPickerBase = kind({
 		 * The maximum value selectable by the picker (inclusive).
 		 *
 		 * The range between `min` and `max` should be evenly divisible by
-		 * [step]{@link moonstone/EditableIntegerPicker.EditableIntegerPickerBase.step}.
+		 * {@link moonstone/EditableIntegerPicker.EditableIntegerPickerBase.step|step}.
 		 *
 		 * @type {Number}
 		 * @required
@@ -65,7 +65,7 @@ const EditableIntegerPickerBase = kind({
 		 * The minimum value selectable by the picker (inclusive).
 		 *
 		 * The range between `min` and `max` should be evenly divisible by
-		 * [step]{@link moonstone/EditableIntegerPicker.EditableIntegerPickerBase.step}.
+		 * {@link moonstone/EditableIntegerPicker.EditableIntegerPickerBase.step|step}.
 		 *
 		 * @type {Number}
 		 * @required
@@ -87,7 +87,7 @@ const EditableIntegerPickerBase = kind({
 		/**
 		 * The icon for the decrementer.
 		 *
-		 * All strings supported by [Icon]{@link moonstone/Icon.Icon} are supported. Without a
+		 * All strings supported by {@link moonstone/Icon.Icon|Icon} are supported. Without a
 		 * custom icon, the default is used.
 		 *
 		 * @type {String}
@@ -96,7 +96,7 @@ const EditableIntegerPickerBase = kind({
 		decrementIcon: PropTypes.string,
 
 		/**
-		 * Disables the picker and prevents [events]{@link /docs/developer-guide/glossary/#event}
+		 * Disables the picker and prevents {@link /docs/developer-guide/glossary/#event|events}
 		 * from firing.
 		 *
 		 * @type {Boolean}
@@ -115,7 +115,7 @@ const EditableIntegerPickerBase = kind({
 		/**
 		 * The icon for the incrementer.
 		 *
-		 * All strings supported by [Icon]{@link moonstone/Icon.Icon} are supported. Without a
+		 * All strings supported by {@link moonstone/Icon.Icon|Icon} are supported. Without a
 		 * custom icon, the default is used.
 		 *
 		 * @type {String}
@@ -163,8 +163,8 @@ const EditableIntegerPickerBase = kind({
 		 * Pads the display value with zeros.
 		 *
 		 * The number of zeros used is the number of digits of the value of
-		 * [min]{@link moonstone/EditableIntegerPicker.EditableIntegerPickerBase.min} or
-		 * [max]{@link moonstone/EditableIntegerPicker.EditableIntegerPickerBase.max}, whichever is
+		 * {@link moonstone/EditableIntegerPicker.EditableIntegerPickerBase.min|min} or
+		 * {@link moonstone/EditableIntegerPicker.EditableIntegerPickerBase.max|max}, whichever is
 		 * greater.
 		 *
 		 * @type {Boolean}

--- a/EditableIntegerPicker/EditableIntegerPickerDecorator.js
+++ b/EditableIntegerPicker/EditableIntegerPickerDecorator.js
@@ -54,7 +54,7 @@ const EditableIntegerPickerDecorator = hoc((config, Wrapped) => {
 
 			/**
 			 * Disables EditableIntegerPicker and does not generate `onChange`
-			 * [events]{@link /docs/developer-guide/glossary/#event}.
+			 * {@link /docs/developer-guide/glossary/#event|events}.
 			 *
 			 * @type {Boolean}
 			 * @public

--- a/ExpandableInput/ExpandableInput.js
+++ b/ExpandableInput/ExpandableInput.js
@@ -43,7 +43,7 @@ const handleUpDown = handle(
 );
 
 /**
- * A stateless component that expands to render a {@link moonstone/Input.Input}.
+ * A stateless component that expands to render a {@link moonstone/Input.Input|Input}.
  *
  * @class ExpandableInputBase
  * @memberof moonstone/ExpandableInput
@@ -325,7 +325,7 @@ class ExpandableInputBase extends Component {
 }
 
 /**
- * A stateful component that expands to render a {@link moonstone/Input.Input}.
+ * A stateful component that expands to render a {@link moonstone/Input.Input|Input}.
  *
  * By default, `ExpandableInput` maintains the state of its `value` property. Supply the
  * `defaultValue` property to control its initial value. If you wish to directly control updates

--- a/ExpandableItem/ExpandableItem.js
+++ b/ExpandableItem/ExpandableItem.js
@@ -55,7 +55,7 @@ function wouldDirectionLeaveContainer (dir, srcNode) {
 }
 
 /**
- * A stateless component that renders a {@link moonstone/LabeledItem.LabeledItem} that can be
+ * A stateless component that renders a {@link moonstone/LabeledItem.LabeledItem|LabeledItem} that can be
  * expanded to show additional contents.
  *
  * @class ExpandableItemBase
@@ -433,7 +433,7 @@ const ExpandableItemBase = kind({
 });
 
 /**
- * A component that renders a {@link moonstone/LabeledItem.LabeledItem} that can be expanded to
+ * A component that renders a {@link moonstone/LabeledItem.LabeledItem|LabeledItem} that can be expanded to
  * show additional contents.
  *
  * `ExpandableItem` maintains its open/closed state by default. The initial state can be supplied

--- a/ExpandableItem/ExpandableItem.js
+++ b/ExpandableItem/ExpandableItem.js
@@ -158,7 +158,7 @@ const ExpandableItemBase = kind({
 		label: PropTypes.node,
 
 		/**
-		 * Prevents the user from moving [Spotlight] {@link /docs/developer-guide/glossary/#spotlight} past the bottom
+		 * Prevents the user from moving {@link /docs/developer-guide/glossary/#spotlight|Spotlight} past the bottom
 		 * of the expandable (when open) using 5-way controls.
 		 *
 		 * @type {Boolean}

--- a/ExpandableList/ExpandableList.js
+++ b/ExpandableList/ExpandableList.js
@@ -62,7 +62,7 @@ const PureGroup = Pure(
 );
 
 /**
- * A stateless component that renders a {@link moonstone/LabeledItem.LabeledItem} that can be
+ * A stateless component that renders a {@link moonstone/LabeledItem.LabeledItem|LabeledItem} that can be
  * expanded to show a selectable list of items.
  *
  * @class ExpandableListBase
@@ -375,7 +375,7 @@ const ExpandableListBase = kind({
 });
 
 /**
- * A component that renders a {@link moonstone/LabeledItem.LabeledItem} that can be expanded to
+ * A component that renders a {@link moonstone/LabeledItem.LabeledItem|LabeledItem} that can be expanded to
  * show a selectable list of items.
  *
  * By default, `ExpandableList` maintains the state of its `selected` property. Supply the

--- a/ExpandableList/ExpandableList.js
+++ b/ExpandableList/ExpandableList.js
@@ -155,7 +155,7 @@ const ExpandableListBase = kind({
 		noAutoClose: PropTypes.bool,
 
 		/**
-		 * Allows the user to move [Spotlight] {@link /docs/developer-guide/glossary/#spotlight} past the bottom of the expandable
+		 * Allows the user to move {@link /docs/developer-guide/glossary/#spotlight|Spotlight} past the bottom of the expandable
 		 * (when open) using 5-way controls.
 		 *
 		 * @type {Boolean}

--- a/ExpandablePicker/ExpandablePicker.js
+++ b/ExpandablePicker/ExpandablePicker.js
@@ -92,9 +92,9 @@ const ExpandablePickerBase = kind({
 		/**
 		 * A custom icon for the decrementer.
 		 *
-		 * All strings supported by [Icon]{@link moonstone/Icon.Icon} are supported. Without a
+		 * All strings supported by {@link moonstone/Icon.Icon|Icon} are supported. Without a
 		 * custom icon, the default is used, and is automatically changed when the
-		 * [orientation]{@link moonstone/Picker.Picker#orientation} is changed.
+		 * {@link moonstone/Picker.Picker#orientation|orientation} is changed.
 		 *
 		 * @type {string}
 		 * @public
@@ -121,9 +121,9 @@ const ExpandablePickerBase = kind({
 		/**
 		 * A custom icon for the incrementer.
 		 *
-		 * All strings supported by [Icon]{@link moonstone/Icon.Icon} are supported. Without a
+		 * All strings supported by {@link moonstone/Icon.Icon|Icon} are supported. Without a
 		 * custom icon, the default is used, and is automatically changed when the
-		 * [orientation]{@link moonstone/Picker.Picker#orientation} is changed.
+		 * {@link moonstone/Picker.Picker#orientation|orientation} is changed.
 		 *
 		 * @type {String}
 		 * @public

--- a/FormCheckbox/FormCheckbox.js
+++ b/FormCheckbox/FormCheckbox.js
@@ -1,7 +1,7 @@
 /**
  * Moonstone styled checkmark icon inside a circle, primarily used inside the
- * [FormCheckboxItem]{@link moonstone/FormCheckboxItem.FormCheckboxItem}. This also has built-in
- * `Spotlight` support since `FormCheckboxItem` is a specialized [Item]{@link moonstone/Item} that
+ * {@link moonstone/FormCheckboxItem.FormCheckboxItem|FormCheckboxItem}. This also has built-in
+ * `Spotlight` support since `FormCheckboxItem` is a specialized {@link moonstone/Item|Item} that
  * does not visually respond to focus; this child component shows focus instead.
  *
  * @example
@@ -37,7 +37,7 @@ const FormCheckboxBase = kind({
 		 *
 		 * May be specified as either:
 		 *
-		 * * A string that represents an icon from the [iconList]{@link ui/Icon.Icon.iconList},
+		 * * A string that represents an icon from the {@link ui/Icon.Icon.iconList|iconList},
 		 * * An HTML entity string, Unicode reference or hex value (in the form '0x...'),
 		 * * A URL specifying path to an icon image, or
 		 * * An object representing a resolution independent resource (See {@link ui/resolution}).

--- a/GridListImageItem/GridListImageItem.js
+++ b/GridListImageItem/GridListImageItem.js
@@ -38,7 +38,7 @@ const
 	);
 
 /**
- * A Moonstone styled base component for [GridListImageItem]{@link moonstone/GridListImageItem.GridListImageItem}.
+ * A Moonstone styled base component for {@link moonstone/GridListImageItem.GridListImageItem|GridListImageItem}.
  *
  * @class GridListImageItemBase
  * @memberof moonstone/GridListImageItem
@@ -77,7 +77,7 @@ const GridListImageItemBase = kind({
 		'data-webos-voice-intent': PropTypes.string,
 
 		/**
-		 * Placeholder image used while [source]{@link moonstone/GridListImageItem.GridListImageItem#source}
+		 * Placeholder image used while {@link moonstone/GridListImageItem.GridListImageItem#source|source}
 		 * is loaded.
 		 *
 		 * @type {String}
@@ -151,7 +151,7 @@ const GridListImageItemBase = kind({
 
 /**
  * Moonstone-specific GridListImageItem behaviors to apply to
- * [GridListImageItem]{@link moonstone/GridListImageItem.GridListImageItem}.
+ * {@link moonstone/GridListImageItem.GridListImageItem|GridListImageItem}.
  *
  * @hoc
  * @memberof moonstone/GridListImageItem

--- a/Heading/Heading.js
+++ b/Heading/Heading.js
@@ -30,7 +30,7 @@ import componentCss from './Heading.module.less';
  * A labeled Heading component.
  *
  * This component is most often not used directly but may be composed within another component as it
- * is within [Heading]{@link moonstone/Heading.Heading}.
+ * is within {@link moonstone/Heading.Heading|Heading}.
  *
  * @class HeadingBase
  * @memberof moonstone/Heading
@@ -88,7 +88,7 @@ const HeadingBase = kind({
 });
 
 /**
- * Applies Moonstone specific behaviors to [HeadingBase]{@link moonstone/Heading.HeadingBase}.
+ * Applies Moonstone specific behaviors to {@link moonstone/Heading.HeadingBase|HeadingBase}.
  *
  * @hoc
  * @memberof moonstone/Heading

--- a/Icon/Icon.js
+++ b/Icon/Icon.js
@@ -60,7 +60,7 @@ const IconBase = kind({
 // Let's find a way to import this list directly, and bonus feature, render our icons in the docs
 // next to their names.
 /**
- * An object whose keys can be used as the child of an [Icon]{@link moonstone/Icon.Icon} component.
+ * An object whose keys can be used as the child of an {@link moonstone/Icon.Icon|Icon} component.
  *
  * List of Icons:
  * ```
@@ -197,7 +197,7 @@ const IconBase = kind({
  */
 
 /**
- * Moonstone-specific behaviors to apply to [IconBase]{@link moonstone/Icon.IconBase}.
+ * Moonstone-specific behaviors to apply to {@link moonstone/Icon.IconBase|IconBase}.
  *
  * @hoc
  * @memberof moonstone/Icon

--- a/IconButton/IconButton.js
+++ b/IconButton/IconButton.js
@@ -1,7 +1,7 @@
 /**
- * An [Icon]{@link moonstone/Icon.Icon} that acts like a [Button]{@link moonstone/Button.Button}.
+ * An {@link moonstone/Icon.Icon|Icon} that acts like a {@link moonstone/Button.Button|Button}.
  * You may specify an image or a font-based icon by setting the `children` to either the path
- * to the image or a string from an [iconList]{@link moonstone/Icon.IconBase.iconList}.
+ * to the image or a string from an {@link moonstone/Icon.IconBase.iconList|iconList}.
  *
  * @example
  * <IconButton size="small">plus</IconButton>
@@ -111,7 +111,7 @@ const IconButtonBase = kind({
 
 /**
  * Moonstone-specific button behaviors to apply to
- * [IconButton]{@link moonstone/IconButton.IconButtonBase}.
+ * {@link moonstone/IconButton.IconButtonBase|IconButton}.
  *
  * @hoc
  * @memberof moonstone/IconButton

--- a/Image/Image.js
+++ b/Image/Image.js
@@ -118,7 +118,7 @@ const ResponsiveImageDecorator = hoc((config, Wrapped) => {
 });
 
 /**
- * Moonstone-specific behaviors to apply to [Image]{@link moonstone/Image.ImageBase}.
+ * Moonstone-specific behaviors to apply to {@link moonstone/Image.ImageBase|Image}.
  *
  * @hoc
  * @memberof moonstone/Image

--- a/IncrementSlider/IncrementSlider.js
+++ b/IncrementSlider/IncrementSlider.js
@@ -53,7 +53,7 @@ const forwardWithType = (type, props) => forward(type, {type}, props);
 
 /**
  * A stateless Slider with IconButtons to increment and decrement the value. In most circumstances,
- * you will want to use the stateful version: {@link moonstone/IncrementSlider.IncrementSlider}.
+ * you will want to use the stateful version: {@link moonstone/IncrementSlider.IncrementSlider|IncrementSlider}.
  *
  * @class IncrementSliderBase
  * @memberof moonstone/IncrementSlider
@@ -604,7 +604,7 @@ const IncrementSliderDecorator = compose(
 const IncrementSlider = IncrementSliderDecorator(IncrementSliderBase);
 
 /**
- * A []{@link moonstone/TooltipDecorator.Tooltip|Tooltip} specifically adapted for use with
+ * A {@link moonstone/TooltipDecorator.Tooltip|Tooltip} specifically adapted for use with
  * {@link moonstone/IncrementSlider.IncrementSlider|IncrementSlider},
  * {@link moonstone/ProgressBar.ProgressBar|ProgressBar}, or
  * {@link moonstone/Slider.Slider|Slider}.

--- a/IncrementSlider/IncrementSlider.js
+++ b/IncrementSlider/IncrementSlider.js
@@ -609,7 +609,7 @@ const IncrementSlider = IncrementSliderDecorator(IncrementSliderBase);
  * {@link moonstone/ProgressBar.ProgressBar|ProgressBar}, or
  * {@link moonstone/Slider.Slider|Slider}.
  *
- * See {@link moonstone/ProgressBar.ProgressBarTooltip}
+ * See {@link moonstone/ProgressBar.ProgressBarTooltip|ProgressBarTooltip}
  *
  * @class IncrementSliderTooltip
  * @memberof moonstone/IncrementSlider

--- a/IncrementSlider/IncrementSlider.js
+++ b/IncrementSlider/IncrementSlider.js
@@ -142,9 +142,9 @@ const IncrementSliderBase = kind({
 		decrementAriaLabel: PropTypes.string,
 
 		/**
-		 * Assign a custom icon for the decrementer. All strings supported by [Icon]{@link moonstone/Icon.Icon} are
+		 * Assign a custom icon for the decrementer. All strings supported by {@link moonstone/Icon.Icon|Icon} are
 		 * supported. Without a custom icon, the default is used, and is automatically changed when
-		 * [vertical]{@link moonstone/IncrementSlider.IncrementSlider#vertical} is changed.
+		 * {@link moonstone/IncrementSlider.IncrementSlider#vertical|vertical} is changed.
 		 *
 		 * @type {String}
 		 * @public
@@ -184,9 +184,9 @@ const IncrementSliderBase = kind({
 		incrementAriaLabel: PropTypes.string,
 
 		/**
-		 * Assign a custom icon for the incrementer. All strings supported by [Icon]{@link moonstone/Icon.Icon} are
+		 * Assign a custom icon for the incrementer. All strings supported by {@link moonstone/Icon.Icon|Icon} are
 		 * supported. Without a custom icon, the default is used, and is automatically changed when
-		 * [vertical]{@link moonstone/IncrementSlider.IncrementSlider#vertical} is changed.
+		 * {@link moonstone/IncrementSlider.IncrementSlider#vertical|vertical} is changed.
 		 *
 		 * @type {String}
 		 * @public
@@ -208,7 +208,7 @@ const IncrementSliderBase = kind({
 		 * The maximum value of the increment slider.
 		 *
 		 * The range between `min` and `max` should be evenly divisible by
-		 * [step]{@link moonstone/IncrementSlider.IncrementSliderBase.step}.
+		 * {@link moonstone/IncrementSlider.IncrementSliderBase.step|step}.
 		 *
 		 * @type {Number}
 		 * @default 100
@@ -220,7 +220,7 @@ const IncrementSliderBase = kind({
 		 * The minimum value of the increment slider.
 		 *
 		 * The range between `min` and `max` should be evenly divisible by
-		 * [step]{@link moonstone/IncrementSlider.IncrementSliderBase.step}.
+		 * {@link moonstone/IncrementSlider.IncrementSliderBase.step|step}.
 		 *
 		 * @type {Number}
 		 * @default 0
@@ -372,7 +372,7 @@ const IncrementSliderBase = kind({
 		 * Enables the built-in tooltip
 		 *
 		 * To customize the tooltip, pass either a custom Tooltip component or an instance of
-		 * [IncrementSliderTooltip]{@link moonstone/IncrementSlider.IncrementSliderTooltip} with
+		 * {@link moonstone/IncrementSlider.IncrementSliderTooltip|IncrementSliderTooltip} with
 		 * additional props configured.
 		 *
 		 * ```
@@ -384,7 +384,7 @@ const IncrementSliderBase = kind({
 		 * ```
 		 *
 		 * The tooltip may also be passed as a child via the `"tooltip"` slot. See
-		 * [Slottable]{@link ui/Slottable} for more information on how slots can be used.
+		 * {@link ui/Slottable|Slottable} for more information on how slots can be used.
 		 *
 		 * ```
 		 * <IncrementSlider>
@@ -604,10 +604,10 @@ const IncrementSliderDecorator = compose(
 const IncrementSlider = IncrementSliderDecorator(IncrementSliderBase);
 
 /**
- * A [Tooltip]{@link moonstone/TooltipDecorator.Tooltip} specifically adapted for use with
- * [IncrementSlider]{@link moonstone/IncrementSlider.IncrementSlider},
- * [ProgressBar]{@link moonstone/ProgressBar.ProgressBar}, or
- * [Slider]{@link moonstone/Slider.Slider}.
+ * A []{@link moonstone/TooltipDecorator.Tooltip|Tooltip} specifically adapted for use with
+ * {@link moonstone/IncrementSlider.IncrementSlider|IncrementSlider},
+ * {@link moonstone/ProgressBar.ProgressBar|ProgressBar}, or
+ * {@link moonstone/Slider.Slider|Slider}.
  *
  * See {@link moonstone/ProgressBar.ProgressBarTooltip}
  *

--- a/IncrementSlider/IncrementSliderButton.js
+++ b/IncrementSlider/IncrementSliderButton.js
@@ -5,8 +5,8 @@ import IconButton from '../IconButton';
 import {onlyUpdateForProps} from '../internal/util';
 
 /**
- * An [IconButton]{@link moonstone/IconButton.IconButton} customized for
- * [IncrementSlider]{@link moonstone/IncrementSlider.IncrementSlider}. It is optimized to only
+ * An {@link moonstone/IconButton.IconButton|IconButton} customized for
+ * {@link moonstone/IncrementSlider.IncrementSlider|IncrementSlider}. It is optimized to only
  * update when `disabled` is changed to minimize unnecessary render cycles.
  *
  * @class IncrementSliderButton

--- a/Input/Input.js
+++ b/Input/Input.js
@@ -99,8 +99,8 @@ const InputBase = kind({
 		iconBefore: PropTypes.string,
 
 		/**
-		 * Indicates [value]{@link moonstone/Input.InputBase.value} is invalid and shows
-		 * [invalidMessage]{@link moonstone/Input.InputBase.invalidMessage}, if set.
+		 * Indicates {@link moonstone/Input.InputBase.value|value} is invalid and shows
+		 * {@link moonstone/Input.InputBase.invalidMessage|invalidMessage}, if set.
 		 *
 		 * @type {Boolean}
 		 * @default false
@@ -110,7 +110,7 @@ const InputBase = kind({
 
 		/**
 		 * The tooltip text to be displayed when the input is
-		 * [invalid]{@link moonstone/Input.InputBase.invalid}.
+		 * {@link moonstone/Input.InputBase.invalid|invalid}.
 		 *
 		 * If this value is *falsy*, the tooltip will be shown with the default message.
 		 *
@@ -166,7 +166,7 @@ const InputBase = kind({
 		onKeyDown: PropTypes.func,
 
 		/**
-		 * Text to display when [value]{@link moonstone/Input.InputBase.value} is not set.
+		 * Text to display when {@link moonstone/Input.InputBase.value|value} is not set.
 		 *
 		 * @type {String}
 		 * @default ''
@@ -197,7 +197,7 @@ const InputBase = kind({
 		 * Accepted values correspond to the standard HTML5 input types.
 		 *
 		 * @type {String}
-		 * @see [MDN input types doc]{@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Form_%3Cinput%3E_types}
+		 * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Form_%3Cinput%3E_types|MDN input types doc}
 		 * @default 'text'
 		 * @public
 		 */

--- a/Input/Input.js
+++ b/Input/Input.js
@@ -31,7 +31,7 @@ import {calcAriaLabel, extractInputProps} from './util';
  *
  * It supports start and end icons. Note that this base component is not stateless as many other
  * base components are. However, it does not support Spotlight. Apps will want to use
- * {@link moonstone/Input.Input}.
+ * {@link moonstone/Input.Input|Input}.
  *
  * @class InputBase
  * @memberof moonstone/Input

--- a/Input/InputSpotlightDecorator.js
+++ b/Input/InputSpotlightDecorator.js
@@ -29,7 +29,7 @@ const handleKeyDown = handle(
 
 
 /**
- * Default config for [InputSpotlightDecorator]{@link moonstone/Input.InputSpotlightDecorator}
+ * Default config for {@link moonstone/Input.InputSpotlightDecorator|InputSpotlightDecorator}
  *
  * @memberof moonstone/Input/InputSpotlightDecorator.InputSpotlightDecorator
  * @hocconfig

--- a/Item/Item.js
+++ b/Item/Item.js
@@ -66,7 +66,7 @@ const ItemBase = kind({
 });
 
 /**
- * Moonstone specific item behaviors to apply to [Item]{@link moonstone/Item.ItemBase}.
+ * Moonstone specific item behaviors to apply to {@link moonstone/Item.ItemBase|Item}.
  *
  * @class ItemDecorator
  * @hoc

--- a/LabeledIcon/LabeledIcon.js
+++ b/LabeledIcon/LabeledIcon.js
@@ -1,8 +1,8 @@
 /**
- * An [Icon]{@link moonstone/Icon.Icon} ecorated with a label.
+ * An {@link moonstone/Icon.Icon|Icon} ecorated with a label.
  *
  * You may specify an image or a font-based icon by setting the `icon` to either the path
- * to the image or a string from an [iconList]{@link moonstone/Icon.IconBase.iconList}.
+ * to the image or a string from an {@link moonstone/Icon.IconBase.iconList|iconList}.
  *
  * @example
  * <LabeledIcon icon="star" labelPosition="after">
@@ -74,7 +74,7 @@ const LabeledIconBase = kind({
 });
 
 /**
- * Adds Moonstone specific behaviors to [LabeledIconBase]{@link moonstone/LabeledIcon.LabeledIconBase}.
+ * Adds Moonstone specific behaviors to {@link moonstone/LabeledIcon.LabeledIconBase|LabeledIconBase}.
  *
  * @hoc
  * @memberof moonstone/LabeledIcon

--- a/LabeledIconButton/LabeledIconButton.js
+++ b/LabeledIconButton/LabeledIconButton.js
@@ -1,9 +1,9 @@
 /**
- * An [Icon]{@link moonstone/Icon.Icon} that acts like a [Button]{@link moonstone/Button.Button}
+ * An {@link moonstone/Icon.Icon|Icon} that acts like a {@link moonstone/Button.Button|Button}
  * decorated with a label.
  *
  * You may specify an image or a font-based icon by setting the `icon` to either the path
- * to the image or a string from an [iconList]{@link moonstone/Icon.IconBase.iconList}.
+ * to the image or a string from an {@link moonstone/Icon.IconBase.iconList|iconList}.
  *
  * @example
  * <LabeledIconButton icon="star" labelPosition="after">
@@ -119,7 +119,7 @@ const LabeledIconButtonBase = kind({
 		 *
 		 * Setting `selected` may be useful when the component represents a toggleable option. The
 		 * visual effect may be customized using the
-		 * [css]{@link moonstone/LabeledIconButton.LabeledIconButtonBase.css} prop.
+		 * {@link moonstone/LabeledIconButton.LabeledIconButtonBase.css|css} prop.
 		 *
 		 * @type {Boolean}
 		 * @public
@@ -154,7 +154,7 @@ const LabeledIconButtonBase = kind({
 });
 
 /**
- * Adds Moonstone specific behaviors to [LabeledIconButtonBase]{@link moonstone/LabeledIconButton.LabeledIconButtonBase}.
+ * Adds Moonstone specific behaviors to {@link moonstone/LabeledIconButton.LabeledIconButtonBase|LabeledIconButtonBase}.
  *
  * @hoc
  * @memberof moonstone/LabeledIconButton

--- a/MoonstoneDecorator/MoonstoneDecorator.js
+++ b/MoonstoneDecorator/MoonstoneDecorator.js
@@ -142,13 +142,12 @@ const defaultConfig = /** @lends moonstone/MoonstoneDecorator.MoonstoneDecorator
 /**
  * A higher-order component that applies Moonstone theming to an application.
  *
- * It also applies [floating layer]{@link ui/FloatingLayer.FloatingLayerDecorator}, [resolution
- * independence]{@link ui/resolution.ResolutionDecorator}, [skin
- * support]{@link moonstone/Skinnable}, [spotlight]{@link spotlight.SpotlightRootDecorator}, and
- * [internationalization support]{@link i18n/I18nDecorator.I18nDecorator}. It is meant to be applied
+ * It also applies {@link ui/FloatingLayer.FloatingLayerDecorator|floating layer}, {@link ui/resolution.ResolutionDecorator|resolution independence},
+ * {@link moonstone/Skinnable|skin support}, {@link spotlight.SpotlightRootDecorator|spotlight}, and
+ * {@link i18n/I18nDecorator.I18nDecorator|internationalization support}. It is meant to be applied
  * to the root element of an app.
  *
- * [Skins]{@link moonstone/Skinnable} provide a way to change the coloration of your app. The
+ * {@link moonstone/Skinnable|Skins} provide a way to change the coloration of your app. The
  * currently supported skins for Moonstone are "moonstone" (the default, dark skin) and
  * "moonstone-light". Use the `skin` property to assign a skin. Ex: `<DecoratedApp skin="light" />`
  *

--- a/MoonstoneDecorator/MoonstoneDecorator.js
+++ b/MoonstoneDecorator/MoonstoneDecorator.js
@@ -1,5 +1,5 @@
 /**
- * Exports the {@link moonstone/MoonstoneDecorator.MoonstoneDecorator} HOC
+ * Exports the {@link moonstone/MoonstoneDecorator.MoonstoneDecorator|MoonstoneDecorator} HOC
  *
  * @module moonstone/MoonstoneDecorator
  * @exports MoonstoneDecorator

--- a/Notification/Notification.js
+++ b/Notification/Notification.js
@@ -34,7 +34,7 @@ const fixTransform = (node) => {
  * A Moonstone styled notification component.
  *
  * It provides a notification modal which can be opened and closed, overlaying an app. Apps will
- * want to use {@link moonstone/Notification.Notification}.
+ * want to use {@link moonstone/Notification.Notification|Notification}.
  *
  * @class NotificationBase
  * @memberof moonstone/Notification

--- a/Panels/AlwaysViewingPanels.js
+++ b/Panels/AlwaysViewingPanels.js
@@ -37,7 +37,7 @@ const AlwaysViewingPanelsDecorator = compose(
 );
 
 /**
- * An instance of [`Panels`]{@link moonstone/Panels.Panels} which restricts the `Panel` to the right
+ * An instance of {@link moonstone/Panels.Panels|Panels} which restricts the `Panel` to the right
  * half of the screen with the left half used for breadcrumbs that allow navigating to previous
  * panels. Typically used for overlaying panels over a screen.
  *

--- a/Panels/Breadcrumb.js
+++ b/Panels/Breadcrumb.js
@@ -26,8 +26,8 @@ export const breadcrumbWidth = 96;
 /**
  * Vertical, transparent bar used to navigate to a prior Panel.
  *
- * [`ActivityPanels`]{@link moonstone/Panels.ActivityPanels} has one breadcrumb, and
- * [`AlwaysViewingPanels`]{@link moonstone/Panels.AlwaysViewingPanels} can have multiple stacked
+ * {@link moonstone/Panels.ActivityPanels|ActivityPanels} has one breadcrumb, and
+ * {@link moonstone/Panels.AlwaysViewingPanels|AlwaysViewingPanels} can have multiple stacked
  * horizontally.
  *
  * @class Breadcrumb

--- a/Panels/Header.js
+++ b/Panels/Header.js
@@ -88,9 +88,9 @@ const HeaderBase = kind({
 		fullBleed: PropTypes.bool,
 
 		/**
-		 * [`Input`]{@link moonstone/Input} element that will replace the `title`.
+		 * {@link moonstone/Input|Input} element that will replace the `title`.
 		 *
-		 * This is also a [slot]{@link ui/Slottable.Slottable}, so it can be referred
+		 * This is also a {@link ui/Slottable.Slottable|slot}, so it can be referred
 		 * to as if it were JSX.
 		 *
 		 * Note: Only applies to `type="standard"` headers.
@@ -131,7 +131,7 @@ const HeaderBase = kind({
 		/**
 		 * Sub-title displayed at the bottom of the panel.
 		 *
-		 * This is a [`slot`]{@link ui/Slottable.Slottable}, so it can be used as a tag-name inside
+		 * This is a {@link ui/Slottable.Slottable|slot}, so it can be used as a tag-name inside
 		 * this component.
 		 *
 		 * @type {String}
@@ -141,7 +141,7 @@ const HeaderBase = kind({
 		/**
 		 * Title of the header.
 		 *
-		 * This is a [`slot`]{@link ui/Slottable.Slottable}, so it can be used as a tag-name inside
+		 * This is a {@link ui/Slottable.Slottable|slot}, so it can be used as a tag-name inside
 		 * this component.
 		 *
 		 * Example:
@@ -160,7 +160,7 @@ const HeaderBase = kind({
 		/**
 		 * Text displayed below the title.
 		 *
-		 * This is a [`slot`]{@link ui/Slottable.Slottable}, so it can be used as a tag-name inside
+		 * This is a {@link ui/Slottable.Slottable|slot}, so it can be used as a tag-name inside
 		 * this component.
 		 *
 		 * @type {String}

--- a/Panels/Panel.js
+++ b/Panels/Panel.js
@@ -12,10 +12,10 @@ import css from './Panel.module.less';
 let panelId = 0;
 
 /**
- * A Panel is the standard view container used inside a [Panels]{@link moonstone/Panels.Panels} view
+ * A Panel is the standard view container used inside a {@link moonstone/Panels.Panels|Panels} view
  * manager instance.
  *
- * [Panels]{@link moonstone/Panels.Panels} will typically contain several instances of these and
+ * {@link moonstone/Panels.Panels|Panels} will typically contain several instances of these and
  * transition between them.
  *
  * @class Panel
@@ -31,7 +31,7 @@ const PanelBase = kind({
 		/**
  		 * The "aria-label" for the Panel.
 		 *
-		 * By default, the panel will be labeled by its [Header]{@link moonstone/Panels.Header}.
+		 * By default, the panel will be labeled by its {@link moonstone/Panels.Header|Header}.
 		 * When `aria-label` is set, it will be used instead to provide an accessibility label for
 		 * the panel.
 		 *
@@ -50,7 +50,7 @@ const PanelBase = kind({
 		 * * Custom Selector - A custom CSS selector may also be provided which will be used to find
 		 *   the target within the Panel
 		 *
-		 * When used within [Panels]{@link moonstone/Panels.Panels}, this prop may be set by
+		 * When used within {@link moonstone/Panels.Panels|Panels}, this prop may be set by
 		 * `Panels` to "default-element" when navigating "forward" to a higher index. This behavior
 		 * may be overridden by setting `autoFocus` on the `Panel` instance as a child of `Panels`
 		 * or by wrapping `Panel` with a custom component and overriding the value passed by
@@ -81,8 +81,8 @@ const PanelBase = kind({
 		/**
 		 * Header for the panel.
 		 *
-		 * This is usually passed by the [Slottable]{@link ui/Slottable.Slottable} API by using a
-		 * [Header]{@link moonstone/Panels.Header} component as a child of the Panel.
+		 * This is usually passed by the {@link ui/Slottable.Slottable|Slottable} API by using a
+		 * {@link moonstone/Panels.Header|Header} component as a child of the Panel.
 		 *
 		 * @type {Header}
 		 * @public
@@ -92,9 +92,9 @@ const PanelBase = kind({
 		/**
 		 * Hides the body components.
 		 *
-		 * When a Panel is used within [`Panels`]{@link moonstone/Panels.Panels},
-		 * [`ActivityPanels`]{@link moonstone/Panels.ActivityPanels}, or
-		 * [`AlwaysViewingPanels`]{@link moonstone/Panels.AlwaysViewingPanels},
+		 * When a Panel is used within {@link moonstone/Panels.Panels|Panels},
+		 * {@link moonstone/Panels.ActivityPanels|ActivityPanels}, or
+		 * {@link moonstone/Panels.AlwaysViewingPanels|AlwaysViewingPanels},
 		 * this property will be set automatically to `true` on render and `false` after animating
 		 * into view.
 		 *

--- a/Panels/Panels.js
+++ b/Panels/Panels.js
@@ -17,7 +17,7 @@ import css from './Panels.module.less';
 const getControlsId = (id) => id && `${id}-controls`;
 
 /**
- * Basic Panels component without breadcrumbs or default [arranger]{@link ui/ViewManager.Arranger}
+ * Basic Panels component without breadcrumbs or default {@link ui/ViewManager.Arranger|arranger}
  *
  * @class Panels
  * @memberof moonstone/Panels
@@ -59,7 +59,7 @@ const PanelsBase = kind({
 		childProps: PropTypes.object,
 
 		/**
-		 * [`Panels`]{@link moonstone/Panels.Panel} to be rendered
+		 * {@link moonstone/Panels.Panel|Panels} to be rendered
 		 *
 		 * @type {Node}
 		 * @public
@@ -119,7 +119,7 @@ const PanelsBase = kind({
 		 *
 		 * When defined, `Panels` will manage the presentation state of `Panel` instances in order
 		 * to restore it when returning to the `Panel`. See
-		 * [noSharedState]{@link moonstone/Panels.Panels.noSharedState} for more details on shared
+		 * {@link moonstone/Panels.Panels.noSharedState|noSharedState} for more details on shared
 		 * state.
 		 *
 		 * @type {String}

--- a/Panels/index.js
+++ b/Panels/index.js
@@ -47,7 +47,7 @@ export {
 	Routable,
 
 	/**
-	 * Used with {@link moonstone/Panels.Routable} to define the `path` segment and the
+	 * Used with {@link moonstone/Panels.Routable|Routable} to define the `path` segment and the
 	 * `component` to render.
 	 *
 	 * @see {@link ui/Routable.Route}

--- a/Picker/Picker.js
+++ b/Picker/Picker.js
@@ -26,7 +26,7 @@ import PickerCore, {PickerItem} from '../internal/Picker';
 /**
  * The base `Picker` component.
  *
- * This version is not [`spottable`]{@link spotlight/Spottable.Spottable}.
+ * This version is not {@link spotlight/Spottable.Spottable|spottable}.
  *
  * @class PickerBase
  * @memberof moonstone/Picker
@@ -73,9 +73,9 @@ const PickerBase = kind({
 		/**
 		 * A custom icon for the decrementer.
 		 *
-		 * All strings supported by [Icon]{@link moonstone/Icon.Icon} are supported. Without a
+		 * All strings supported by {@link moonstone/Icon.Icon|Icon} are supported. Without a
 		 * custom icon, the default is used, and is automatically changed when the
-		 * [orientation]{@link moonstone/Picker.Picker#orientation} is changed.
+		 * {@link moonstone/Picker.Picker#orientation|orientation} is changed.
 		 *
 		 * @type {String}
 		 * @public
@@ -93,9 +93,9 @@ const PickerBase = kind({
 		/**
 		 * A custom icon for the incrementer.
 		 *
-		 * All strings supported by [Icon]{@link moonstone/Icon.Icon} are supported. Without a
+		 * All strings supported by {@link moonstone/Icon.Icon|Icon} are supported. Without a
 		 * custom icon, the default is used, and is automatically changed when the
-		 * [orientation]{@link moonstone/Picker.Picker#orientation} is changed.
+		 * {@link moonstone/Picker.Picker#orientation|orientation} is changed.
 		 *
 		 * @type {String}
 		 * @public
@@ -119,7 +119,7 @@ const PickerBase = kind({
 		 * Disables marqueeing of items.
 		 *
 		 * By default, each picker item is wrapped by a
-		 * [`Marquee`]{@link moonstone/Marquee.Marquee}. When this is set, the items will
+		 * {@link moonstone/Marquee.Marquee|Marquee}. When this is set, the items will
 		 * not be wrapped.
 		 *
 		 * @type {Boolean}

--- a/Popup/Popup.js
+++ b/Popup/Popup.js
@@ -144,8 +144,8 @@ const PopupBase = kind({
 		/**
 		 * Tells the body element to shrink to the size of the content.
 		 *
-		 * Popup is composed of a [Layout]{@link ui/Layout.Layout} and [Cells]{@link ui/Layout.Cell}.
-		 * This informs the body cell to use the [shrink]{@link ui/Layout.Cell#shrink} property so
+		 * Popup is composed of a {@link ui/Layout.Layout|Layout} and {@link ui/Layout.Cell|Cells}.
+		 * This informs the body cell to use the {@link ui/Layout.Cell#shrink|shrink} property so
 		 * it will match the dimensions of its contents rather than expand to the width of the
 		 * Popup's assigned dimensions.
 		 *
@@ -169,7 +169,7 @@ const PopupBase = kind({
 		 *
 		 * It can be either `'none'`, `'self-first'`, or `'self-only'`.
 		 *
-		 * Note: The ready-to-use [Popup]{@link moonstone/Popup.Popup} component only supports
+		 * Note: The ready-to-use {@link moonstone/Popup.Popup|Popup} component only supports
 		 * `'self-first'` and `'self-only'`.
 		 *
 		 * @type {String}
@@ -270,7 +270,7 @@ const OpenState = {
 
 /**
  * A stateful component that renders a popup in a
- * [FloatingLayer]{@link ui/FloatingLayer.FloatingLayer}.
+ * {@link ui/FloatingLayer.FloatingLayer|FloatingLayer}.
  *
  * @class Popup
  * @memberof moonstone/Popup
@@ -344,7 +344,7 @@ class Popup extends Component {
 		 * Called after show transition has completed, and immediately with no transition.
 		 *
 		 * Note: The function does not run if Popup is initially opened and
-		 * [noAnimation]{@link moonstone/Popup.PopupBase#noAnimation} is `true`.
+		 * {@link moonstone/Popup.PopupBase#noAnimation|noAnimation} is `true`.
 		 *
 		 * @type {Function}
 		 * @public

--- a/ProgressBar/ProgressBar.js
+++ b/ProgressBar/ProgressBar.js
@@ -81,7 +81,7 @@ const ProgressBarBase = kind({
 		 * Enables the built-in tooltip.
 		 *
 		 * To customize the tooltip, pass either a custom tooltip component or an instance of
-		 * [ProgressBarTooltip]{@link moonstone/ProgressBar.ProgressBarTooltip} with additional
+		 * {@link moonstone/ProgressBar.ProgressBarTooltip|ProgressBarTooltip} with additional
 		 * props configured.
 		 *
 		 * The provided component will receive the following props from `ProgressBar`:
@@ -102,7 +102,7 @@ const ProgressBarBase = kind({
 		 * ```
 		 *
 		 * The tooltip may also be passed as a child via the `"tooltip"` slot. See
-		 * [Slottable]{@link ui/Slottable} for more information on how slots can be used.
+		 * {@link ui/Slottable|Slottable} for more information on how slots can be used.
 		 *
 		 * Usage:
 		 * ```
@@ -156,7 +156,7 @@ const ProgressBarBase = kind({
 });
 
 /**
- * Moonstone-specific behaviors to apply to [ProgressBar]{@link moonstone/ProgressBar.ProgressBarBase}.
+ * Moonstone-specific behaviors to apply to {@link moonstone/ProgressBar.ProgressBarBase|ProgressBar}.
  *
  * @hoc
  * @memberof moonstone/ProgressBar

--- a/ProgressBar/ProgressBarTooltip.js
+++ b/ProgressBar/ProgressBarTooltip.js
@@ -95,10 +95,10 @@ const getSide = (orientation, side, position) => {
 };
 
 /**
- * A [Tooltip]{@link moonstone/TooltipDecorator.Tooltip} specifically adapted for use with
- * [IncrementSlider]{@link moonstone/IncrementSlider.IncrementSlider},
- * [ProgressBar]{@link moonstone/ProgressBar.ProgressBar}, or
- * [Slider]{@link moonstone/Slider.Slider}.
+ * A {@link moonstone/TooltipDecorator.Tooltip|Tooltip} specifically adapted for use with
+ * {@link moonstone/IncrementSlider.IncrementSlider|IncrementSlider},
+ * {@link moonstone/ProgressBar.ProgressBar|ProgressBar}, or
+ * {@link moonstone/Slider.Slider|Slider}.
  *
  * @class ProgressBarTooltip
  * @memberof moonstone/ProgressBar

--- a/RangePicker/RangePicker.js
+++ b/RangePicker/RangePicker.js
@@ -42,7 +42,7 @@ const RangePickerBase = kind({
 		 * The maximum value selectable by the picker (inclusive).
 		 *
 		 * The range between `min` and `max` should be evenly divisible by
-		 * [step]{@link moonstone/RangePicker.RangePickerBase.step}.
+		 * {@link moonstone/RangePicker.RangePickerBase.step|step}.
 		 *
 		 * @type {Number}
 		 * @required
@@ -54,7 +54,7 @@ const RangePickerBase = kind({
 		 * The minimum value selectable by the picker (inclusive).
 		 *
 		 * The range between `min` and `max` should be evenly divisible by
-		 * [step]{@link moonstone/RangePicker.RangePickerBase.step}.
+		 * {@link moonstone/RangePicker.RangePickerBase.step|step}.
 		 *
 		 * @type {Number}
 		 * @required
@@ -101,9 +101,9 @@ const RangePickerBase = kind({
 		/**
 		 * A custom icon for the decrementer.
 		 *
-		 * All strings supported by [Icon]{@link moonstone/Icon.Icon} are supported. Without a
+		 * All strings supported by {@link moonstone/Icon.Icon|Icon} are supported. Without a
 		 * custom icon, the default is used, and is automatically changed when the
-		 * [orientation]{@link moonstone/RangePicker.RangePicker#orientation} is changed.
+		 * {@link moonstone/RangePicker.RangePicker#orientation|orientation} is changed.
 		 *
 		 * @type {string}
 		 * @public
@@ -121,9 +121,9 @@ const RangePickerBase = kind({
 		/**
 		 * A custom icon for the incrementer.
 		 *
-		 * All strings supported by [Icon]{@link moonstone/Icon.Icon} are supported. Without a
+		 * All strings supported by {@link moonstone/Icon.Icon|Icon} are supported. Without a
 		 * custom icon, the default is used, and is automatically changed when the
-		 * [orientation]{@link moonstone/RangePicker.RangePicker#orientation} is changed.
+		 * {@link moonstone/RangePicker.RangePicker#orientation|orientation} is changed.
 		 *
 		 * @type {String}
 		 * @public

--- a/Region/Region.js
+++ b/Region/Region.js
@@ -28,7 +28,7 @@ const RegionBase = kind({
 
 	propTypes: /** @lends moonstone/Region.Region.prototype */ {
 		/**
-		 * Title placed within an instance of [Heading]{@link moonstone/Heading.Heading} before the
+		 * Title placed within an instance of {@link moonstone/Heading.Heading|Heading} before the
 		 * children.
 		 *
 		 * @type {String}

--- a/Scrollable/ScrollButton.js
+++ b/Scrollable/ScrollButton.js
@@ -8,8 +8,8 @@ import IconButton from '../IconButton';
 import css from './Scrollbar.module.less';
 
 /**
- * An [IconButton]{@link moonstone/IconButton.IconButton} used within
- * a [Scrollbar]{@link moonstone/Scrollable.Scrollbar}.
+ * An {@link moonstone/IconButton.IconButton|IconButton} used within
+ * a {@link moonstone/Scrollable.Scrollbar|Scrollbar}.
  *
  * @class ScrollButton
  * @memberof moonstone/Scrollable

--- a/Scrollable/ScrollButtons.js
+++ b/Scrollable/ScrollButtons.js
@@ -34,7 +34,7 @@ const
 	};
 
 /**
- * A Moonstone-styled scroll buttons. It is used in [Scrollbar]{@link moonstone/Scrollable.Scrollbar}.
+ * A Moonstone-styled scroll buttons. It is used in {@link moonstone/Scrollable.Scrollbar|Scrollbar}.
  *
  * @class ScrollButtons
  * @memberof moonstone/Scrollable

--- a/Scrollable/ScrollThumb.js
+++ b/Scrollable/ScrollThumb.js
@@ -16,7 +16,7 @@ const nop = () => {};
 class ScrollThumb extends Component {
 	static propTypes = /** @lends moonstone/Scrollable.ScrollThumb.prototype */ {
 		/**
-		 * Called when [ScrollThumb]{@link moonstone/Scrollable.ScrollThumb} is updated.
+		 * Called when {@link moonstone/Scrollable.ScrollThumb|ScrollThumb} is updated.
 		 *
 		 * @type {Function}
 		 * @private

--- a/Scrollable/Scrollable.js
+++ b/Scrollable/Scrollable.js
@@ -50,8 +50,8 @@ const
 
 /**
  * The name of a custom attribute which indicates the index of an item in
- * [VirtualList]{@link moonstone/VirtualList.VirtualList} or
- * [VirtualGridList]{@link moonstone/VirtualList.VirtualGridList}.
+ * {@link moonstone/VirtualList.VirtualList|VirtualList} or
+ * {@link moonstone/VirtualList.VirtualGridList|VirtualGridList}.
  *
  * @constant dataIndexAttribute
  * @memberof moonstone/Scrollable
@@ -182,7 +182,7 @@ class ScrollableBase extends Component {
 
 		/**
 		 * Direction of the list or the scroller.
-		 * `'both'` could be only used for[Scroller]{@link moonstone/Scroller.Scroller}.
+		 * `'both'` could be only used for {@link moonstone/Scroller.Scroller|Scroller}.
 		 *
 		 * Valid values are:
 		 * * `'both'`,

--- a/Scrollable/ScrollableNative.js
+++ b/Scrollable/ScrollableNative.js
@@ -163,7 +163,7 @@ class ScrollableBaseNative extends Component {
 
 		/**
 		 * Direction of the list or the scroller.
-		 * `'both'` could be only used for[Scroller]{@link moonstone/Scroller.Scroller}.
+		 * `'both'` could be only used for {@link moonstone/Scroller.Scroller|Scroller}.
 		 *
 		 * Valid values are:
 		 * * `'both'`,

--- a/Scrollable/Scrollbar.js
+++ b/Scrollable/Scrollbar.js
@@ -23,7 +23,7 @@ class ScrollbarBase extends Component {
 
 	static propTypes = /** @lends moonstone/Scrollable.Scrollbar.prototype */ {
 		/**
-		 * Called when [ScrollThumb]{@link moonstone/Scrollable.ScrollThumb} is updated.
+		 * Called when {@link moonstone/Scrollable.ScrollThumb|ScrollThumb} is updated.
 		 *
 		 * @type {Function}
 		 * @private
@@ -54,7 +54,7 @@ class ScrollbarBase extends Component {
 
 		/**
 		 * `true` if rtl, `false` if ltr.
-		 * Normally, [Scrollable]{@link ui/Scrollable.Scrollable} should set this value.
+		 * Normally, {@link ui/Scrollable.Scrollable|Scrollable} should set this value.
 		 *
 		 * @type {Boolean}
 		 * @private
@@ -145,7 +145,7 @@ class ScrollbarBase extends Component {
 }
 
 /**
- * A Moonstone-styled scroll bar. It is used in [Scrollable]{@link moonstone/Scrollable.Scrollable}.
+ * A Moonstone-styled scroll bar. It is used in {@link moonstone/Scrollable.Scrollable|Scrollable}.
  *
  * @class Scrollbar
  * @memberof moonstone/Scrollable

--- a/Scroller/Scroller.js
+++ b/Scroller/Scroller.js
@@ -29,10 +29,10 @@ import ScrollableNative from '../Scrollable/ScrollableNative';
 const dataContainerDisabledAttribute = 'data-spotlight-container-disabled';
 
 /**
- * A Moonstone-styled base component for [Scroller]{@link moonstone/Scroller.Scroller}.
+ * A Moonstone-styled base component for {@link moonstone/Scroller.Scroller|Scroller}.
  * In most circumstances, you will want to use the
- * [SpotlightContainerDecorator]{@link spotlight/SpotlightContainerDecorator.SpotlightContainerDecorator}
- * and the Scrollable version, [Scroller]{@link moonstone/Scroller.Scroller}.
+ * {@link spotlight/SpotlightContainerDecorator.SpotlightContainerDecorator|SpotlightContainerDecorator}
+ * and the Scrollable version, {@link moonstone/Scroller.Scroller|Scroller}.
  *
  * @class ScrollerBase
  * @memberof moonstone/Scroller
@@ -45,7 +45,7 @@ class ScrollerBase extends Component {
 
 	static propTypes = /** @lends moonstone/Scroller.ScrollerBase.prototype */ {
 		/**
-		 * Passes the instance of [Scroller]{@link ui/Scroller.Scroller}.
+		 * Passes the instance of {@link ui/Scroller.Scroller|Scroller}.
 		 *
 		 * @type {Object}
 		 * @param {Object} ref
@@ -54,7 +54,7 @@ class ScrollerBase extends Component {
 		initUiChildRef: PropTypes.func,
 
 		/**
-		 * Called when [Scroller]{@link moonstone/Scroller.Scroller} updates.
+		 * Called when {@link moonstone/Scroller.Scroller|Scroller} updates.
 		 *
 		 * @type {function}
 		 * @private
@@ -70,7 +70,7 @@ class ScrollerBase extends Component {
 		rtl: PropTypes.bool,
 
 		/**
-		 * Called when [Scroller]{@link moonstone/Scroller.Scroller} should be scrolled
+		 * Called when {@link moonstone/Scroller.Scroller|Scroller} should be scrolled
 		 * and the focus should be moved to a scrollbar button.
 		 *
 		 * @type {function}
@@ -386,7 +386,7 @@ class ScrollerBase extends Component {
 /**
  * Unique identifier for the component.
  *
- * When defined and when the `Scroller` is within a [Panel]{@link moonstone/Panels.Panel}, the
+ * When defined and when the `Scroller` is within a {@link moonstone/Panels.Panel|Panel}, the
  * `Scroller` will store its scroll position and restore that position when returning to the
  * `Panel`.
  *

--- a/SelectableItem/SelectableItem.js
+++ b/SelectableItem/SelectableItem.js
@@ -1,5 +1,5 @@
 /**
- * Provides a Moonstone-themed [Item]{@link moonstone/Item} with an icon that toggles on and off.
+ * Provides a Moonstone-themed {@link moonstone/Item|Item} with an icon that toggles on and off.
  *
  * @example
  * <SelectableItem>Click Me</SelectableItem>
@@ -20,7 +20,7 @@ import SelectableIcon from './SelectableIcon';
 import componentCss from './SelectableItem.module.less';
 
 /**
- * Renders an [Item]{@link moonstone/Item} with a circle icon, by default.
+ * Renders an {@link moonstone/Item|Item} with a circle icon, by default.
  *
  * @class SelectableItemBase
  * @memberof moonstone/SelectableItem

--- a/Skinnable/Skinnable.js
+++ b/Skinnable/Skinnable.js
@@ -1,5 +1,5 @@
 /**
- * Exports the {@link moonstone/Skinnable.Skinnable} higher-order component (HOC).
+ * Exports the {@link moonstone/Skinnable.Skinnable|Skinnable} higher-order component (HOC).
  *
  * @module moonstone/Skinnable
  * @exports Skinnable

--- a/Skinnable/Skinnable.js
+++ b/Skinnable/Skinnable.js
@@ -19,7 +19,7 @@ const defaultConfig = {
 };
 
 /**
- * This higher-order component is based on [ui/Skinnable]{@link ui/Skinnable.Skinnable}.
+ * This higher-order component is based on {@link ui/Skinnable.Skinnable|ui/Skinnable}.
  *
  * `Skinnable` comes pre-configured for Moonstone's supported skins: "dark" (default) and "light".
  * It is used to apply the relevant skinning classes to each component and has been used to

--- a/Slider/Slider.js
+++ b/Slider/Slider.js
@@ -110,7 +110,7 @@ const SliderBase = kind({
 		 * The maximum value of the slider.
 		 *
 		 * The range between `min` and `max` should be evenly divisible by
-		 * [step]{@link moonstone/Slider.SliderBase.step}.
+		 * {@link moonstone/Slider.SliderBase.step|step}.
 		 *
 		 * @type {Number}
 		 * @default 100
@@ -122,7 +122,7 @@ const SliderBase = kind({
 		 * The minimum value of the slider.
 		 *
 		 * The range between `min` and `max` should be evenly divisible by
-		 * [step]{@link moonstone/Slider.SliderBase.step}.
+		 * {@link moonstone/Slider.SliderBase.step|step}.
 		 *
 		 * @type {Number}
 		 * @default 0
@@ -179,7 +179,7 @@ const SliderBase = kind({
 		 * Enables the built-in tooltip
 		 *
 		 * To customize the tooltip, pass either a custom tooltip component or an instance of
-		 * [SliderTooltip]{@link moonstone/Slider.SliderTooltip} with additional props configured.
+		 * {@link moonstone/Slider.SliderTooltip|SliderTooltip} with additional props configured.
 		 *
 		 * ```
 		 * <Slider
@@ -190,7 +190,7 @@ const SliderBase = kind({
 		 * ```
 		 *
 		 * The tooltip may also be passed as a child via the `"tooltip"` slot. See
-		 * [Slottable]{@link ui/Slottable} for more information on how slots can be used.
+		 * {@link ui/Slottable|Slottable} for more information on how slots can be used.
 		 *
 		 * ```
 		 * <Slider>
@@ -302,7 +302,7 @@ const SliderBase = kind({
 });
 
 /**
- * Moonstone-specific slider behaviors to apply to [SliderBase]{@link moonstone/Slider.SliderBase}.
+ * Moonstone-specific slider behaviors to apply to {@link moonstone/Slider.SliderBase|SliderBase}.
  *
  * @hoc
  * @memberof moonstone/Slider
@@ -323,8 +323,8 @@ const SliderDecorator = compose(
 );
 
 /**
- * Slider input with Moonstone styling, [`Spottable`]{@link spotlight/Spottable.Spottable},
- * [Touchable]{@link ui/Touchable} and [`SliderDecorator`]{@link moonstone/Slider.SliderDecorator}
+ * Slider input with Moonstone styling, {@link spotlight/Spottable.Spottable|Spottable},
+ * {@link ui/Touchable|Touchable} and {@link moonstone/Slider.SliderDecorator|SliderDecorator}
  * applied.
  *
  * By default, `Slider` maintains the state of its `value` property. Supply the `defaultValue`
@@ -354,10 +354,10 @@ const SliderDecorator = compose(
 const Slider = SliderDecorator(SliderBase);
 
 /**
- * A [Tooltip]{@link moonstone/TooltipDecorator.Tooltip} specifically adapted for use with
- * [IncrementSlider]{@link moonstone/IncrementSlider.IncrementSlider},
- * [ProgressBar]{@link moonstone/ProgressBar.ProgressBar}, or
- * [Slider]{@link moonstone/Slider.Slider}.
+ * A {@link moonstone/TooltipDecorator.Tooltip|Tooltip} specifically adapted for use with
+ * {@link moonstone/IncrementSlider.IncrementSlider|IncrementSlider},
+ * {@link moonstone/ProgressBar.ProgressBar|ProgressBar}, or
+ * {@link moonstone/Slider.Slider|Slider}.
  *
  * @see {@link moonstone/ProgressBar.ProgressBarTooltip}
  * @class SliderTooltip

--- a/Spinner/Spinner.js
+++ b/Spinner/Spinner.js
@@ -220,7 +220,7 @@ const SpinnerSpotlightDecorator = hoc((config, Wrapped) => {
 });
 
 /**
- * Moonstone-specific Spinner behaviors to apply to [Spinner]{@link moonstone/Spinner.Spinner}.
+ * Moonstone-specific Spinner behaviors to apply to {@link moonstone/Spinner.Spinner|Spinner}.
  *
  * @hoc
  * @memberof moonstone/Spinner

--- a/Spinner/Spinner.js
+++ b/Spinner/Spinner.js
@@ -108,7 +108,7 @@ const SpinnerBase = kind({
 		 * Customize the size of this component.
 		 *
 		 * Recommended usage is "medium" (default) for standalone and popup scenarios, while "small"
-		 * is best suited for use inside other elements, like {@link moonstone/SlotItem.SlotItem}.
+		 * is best suited for use inside other elements, like {@link moonstone/SlotItem.SlotItem|SlotItem}.
 		 *
 		 * @type {('medium'|'small')}
 		 * @default 'medium'

--- a/SwitchItem/SwitchItem.js
+++ b/SwitchItem/SwitchItem.js
@@ -22,7 +22,7 @@ import ToggleItem from '../ToggleItem';
 import componentCss from './SwitchItem.module.less';
 
 /**
- * Renders an item with a [Switch]{@link moonstone/Switch}.
+ * Renders an item with a {@link moonstone/Switch|Switch}.
  *
  * @class SwitchItem
  * @memberof moonstone/SwitchItem

--- a/TimePicker/TimePicker.js
+++ b/TimePicker/TimePicker.js
@@ -199,8 +199,8 @@ const dateTimeConfig = {
 /**
  * A component that allows displaying or selecting time.
  *
- * Set the [value]{@link moonstone/TimePicker.TimePicker#value} property to a standard JavaScript
- * [Date] {@link /docs/developer-guide/glossary/#date} object to initialize the picker.
+ * Set the {@link moonstone/TimePicker.TimePicker#value|value} property to a standard JavaScript
+ *  {@link /docs/developer-guide/glossary/#date|Date} object to initialize the picker.
  *
  * By default, `TimePicker` maintains the state of its `value` property. Supply the
  * `defaultValue` property to control its initial value. If you wish to directly control updates

--- a/TimePicker/TimePickerBase.js
+++ b/TimePicker/TimePickerBase.js
@@ -70,9 +70,9 @@ class HourPicker extends Component {
 }
 
 /**
-* {@link moonstone/TimePicker.TimePickerBase} is the stateless functional time picker
+* {@link moonstone/TimePicker.TimePickerBase|TimePickerBase} is the stateless functional time picker
 * component. Should not be used directly but may be composed within another component as it is
-* within {@link moonstone/TimePicker.TimePicker}.
+* within {@link moonstone/TimePicker.TimePicker|TimePicker}.
 *
 * @class TimePickerBase
 * @memberof moonstone/TimePicker

--- a/ToggleButton/ToggleButton.js
+++ b/ToggleButton/ToggleButton.js
@@ -20,7 +20,7 @@ import Skinnable from '../Skinnable';
 import css from './ToggleButton.module.less';
 
 /**
- * A stateless [Button]{@link moonstone/Button.Button} that can be toggled by changing its
+ * A stateless {@link moonstone/Button.Button|Button} that can be toggled by changing its
  * `selected` property.
  *
  * @class ToggleButtonBase

--- a/ToggleIcon/ToggleIcon.js
+++ b/ToggleIcon/ToggleIcon.js
@@ -2,21 +2,20 @@
  * Provides Moonstone-themed Icon component with interactive toggleable capabilities.
  *
  * `ToggleIcon` does not implement a visual change when a user interacts with the control and must
- * be customized by the consumer using [css className
- * overrides]{@link ui/ToggleIcon.ToggleIconBase.css}.
+ * be customized by the consumer using {@link ui/ToggleIcon.ToggleIconBase.css|css className overrides}.
  *
- * Often, an [Icon value]{@link moonstone/Icon.Icon} is passed as `children` to represent the
+ * Often, an {@link moonstone/Icon.Icon|Icon value} is passed as `children` to represent the
  * selected state but is not required. Omitting `children` allows the consumer to implement more
  * advanced approaches such as styling the `::before` and `::after` pseudo-elements to save a DOM
  * node.
  *
  * The following Moonstone components use `ToggleIcon`, and make good examples of various usages.
  *
- * * [Checkbox]{@link moonstone/Checkbox.Checkbox},
- * * [FormCheckbox]{@link moonstone/FormCheckbox.FormCheckbox},
- * * [Switch]{@link moonstone/Switch.Switch},
- * * [RadioItem]{@link moonstone/RadioItem.RadioItem}, and
- * * [SelectableItem]{@link moonstone/SelectableItem.SelectableItem}.
+ * * {@link moonstone/Checkbox.Checkbox|Checkbox},
+ * * {@link moonstone/FormCheckbox.FormCheckbox|FormCheckbox},
+ * * {@link moonstone/Switch.Switch|Switch},
+ * * {@link moonstone/RadioItem.RadioItem|RadioItem}, and
+ * * {@link moonstone/SelectableItem.SelectableItem|SelectableItem}.
  *
  * @example
  * <ToggleIcon onToggle={(props)=> console.log(props.selected)}>
@@ -70,7 +69,7 @@ const ToggleIconDecorator = compose(
 );
 
 /**
- * A customizable Moonstone starting point [Icon]{@link moonstone/Icon.Icon} that responds to the
+ * A customizable Moonstone starting point {@link moonstone/Icon.Icon|Icon} that responds to the
  * `selected` prop.
  *
  * @class ToggleIcon

--- a/ToggleItem/ToggleItem.js
+++ b/ToggleItem/ToggleItem.js
@@ -1,10 +1,10 @@
 /**
- * A Moonstone-themed [Item]{@link moonstone/Item} used as the basis for other stylized toggle item
+ * A Moonstone-themed {@link moonstone/Item|Item} used as the basis for other stylized toggle item
  * components.
  *
  * Note: This is not intended to be used directly, but should be extended by a component that will
  * customize this component's appearance by supplying an
- * [iconComponent prop]{@link moonstone/ToggleItem.ToggleItemBase#iconComponent}.
+ * {@link moonstone/ToggleItem.ToggleItemBase#iconComponent|iconComponent prop}.
  *
  * @example
  * <ToggleItem
@@ -38,7 +38,7 @@ import {SlotItemBase} from '../SlotItem';
 import componentCss from './ToggleItem.module.less';
 
 /**
- * A Moonstone-styled toggle [Item]{@link moonstone/Item} without any behavior.
+ * A Moonstone-styled toggle {@link moonstone/Item|Item} without any behavior.
  *
  * @class ToggleItemBase
  * @memberof moonstone/ToggleItem
@@ -62,7 +62,7 @@ const ToggleItemBase = kind({
 		 * The icon component to render in this item.
 		 *
 		 * This component receives the `selected` prop and value, and must therefore respond to it in some
-		 * way. It is recommended to use [ToggleIcon]{@link moonstone/ToggleIcon} for this.
+		 * way. It is recommended to use {@link moonstone/ToggleIcon|ToggleIcon} for this.
 		 *
 		 * @type {Component|Element}
 		 * @required
@@ -86,7 +86,7 @@ const ToggleItemBase = kind({
 		/**
 		 * Overrides the icon of the `iconComponent` component.
 		 *
-		 * This accepts any string that the [Icon]{@link moonstone/Icon.Icon} component supports,
+		 * This accepts any string that the {@link moonstone/Icon.Icon|Icon} component supports,
 		 * provided the recommendations of `iconComponent` are followed.
 		 *
 		 * @type {String}
@@ -173,7 +173,7 @@ const ToggleItem = ToggleItemDecorator(ToggleItemBase);
  * The Icon to render in this item.
  *
  * This component receives the `selected` prop and value, and must therefore respond to it in some
- * way. It is recommended to use [ToggleIcon]{@link moonstone/ToggleIcon} for this.
+ * way. It is recommended to use {@link moonstone/ToggleIcon|ToggleIcon} for this.
  *
  * @name iconComponent
  * @memberof moonstone/ToggleItem.ToggleItem.prototype

--- a/TooltipDecorator/TooltipDecorator.js
+++ b/TooltipDecorator/TooltipDecorator.js
@@ -24,7 +24,7 @@ import {adjustDirection, adjustAnchor, calcOverflow, getLabelOffset, getPosition
 let currentTooltip; // needed to know whether or not we should stop a showing job when unmounting
 
 /**
- * Default config for [TooltipDecorator]{@link moonstone/TooltipDecorator.TooltipDecorator}
+ * Default config for {@link moonstone/TooltipDecorator.TooltipDecorator|TooltipDecorator}
  *
  * @memberof moonstone/TooltipDecorator.TooltipDecorator
  * @hocconfig
@@ -35,7 +35,7 @@ const defaultConfig = {
 	 * flipping to an alternate orientation or adjusting its offset to remain on screen.
 	 * The default of 24 is derived from a standard 12px screen-keepout size plus the standard
 	 * Spotlight-outset (12px) margin/padding value which keeps elements and text aligned inside a
-	 * [Panel]{@link moonstone/Panels.Panel}. Note: This value will be scaled according to the
+	 * {@link moonstone/Panels.Panel|Panel}. Note: This value will be scaled according to the
 	 * resolution.
 	 *
 	 * @type {Number}
@@ -59,7 +59,7 @@ const defaultConfig = {
 };
 
 /**
- * A higher-order component which positions [Tooltip]{@link moonstone/TooltipDecorator.Tooltip} in
+ * A higher-order component which positions {@link moonstone/TooltipDecorator.Tooltip|Tooltip} in
  * relation to the wrapped component.
  *
  * The tooltip is automatically displayed when the decoratorated component is focused after a set

--- a/VideoPlayer/MediaControls.js
+++ b/VideoPlayer/MediaControls.js
@@ -456,7 +456,7 @@ const MediaControlsBase = kind({
 });
 
 /**
- * Media control behaviors to apply to [MediaControlsBase]{@link moonstone/VideoPlayer.MediaControlsBase}.
+ * Media control behaviors to apply to {@link moonstone/VideoPlayer.MediaControlsBase|MediaControlsBase}.
  * Provides built-in support for showing more components and key handling for basic playback
  * controls.
  *

--- a/VideoPlayer/MediaControls.js
+++ b/VideoPlayer/MediaControls.js
@@ -266,7 +266,7 @@ const MediaControlsBase = kind({
 
 		/**
 		 * A string which is sent to the `play` icon of the player controls. This can be
-		 * anything that is accepted by {@link moonstone/Icon.Icon}. This will be temporarily replaced by
+		 * anything that is accepted by {@link moonstone/Icon.Icon|Icon}. This will be temporarily replaced by
 		 * the {@link moonstone/VideoPlayer.MediaControls.pauseIcon|pauseIcon} when the
 		 * {@link moonstone/VideoPlayer.MediaControls.paused|paused} boolean is `true`.
 		 *

--- a/VideoPlayer/MediaControls.js
+++ b/VideoPlayer/MediaControls.js
@@ -57,8 +57,8 @@ const MediaControlsBase = kind({
 	// intentionally assigning these props to MediaControls instead of Base (which is private)
 	propTypes: /** @lends moonstone/VideoPlayer.MediaControls.prototype */ {
 		/**
-		 * Reverse-playback [icon]{@link moonstone/Icon.Icon} name. Accepts any
-		 * [icon]{@link moonstone/Icon.Icon} component type.
+		 * Reverse-playback {@link moonstone/Icon.Icon|icon} name. Accepts any
+		 * {@link moonstone/Icon.Icon|icon} component type.
 		 *
 		 * @type {String}
 		 * @default 'backward'
@@ -67,8 +67,8 @@ const MediaControlsBase = kind({
 		backwardIcon: PropTypes.string,
 
 		/**
-		 * Forward [icon]{@link moonstone/Icon.Icon} name. Accepts any
-		 * [icon]{@link moonstone/Icon.Icon} component type.
+		 * Forward {@link moonstone/Icon.Icon|icon} name. Accepts any
+		 * {@link moonstone/Icon.Icon|icon} component type.
 		 *
 		 * @type {String}
 		 * @default 'forward'
@@ -77,8 +77,8 @@ const MediaControlsBase = kind({
 		forwardIcon: PropTypes.string,
 
 		/**
-		 * Jump backward [icon]{@link moonstone/Icon.Icon} name. Accepts any
-		 * [icon]{@link moonstone/Icon.Icon} component type.
+		 * Jump backward {@link moonstone/Icon.Icon|icon} name. Accepts any
+		 * {@link moonstone/Icon.Icon|icon} component type.
 		 *
 		 * @type {String}
 		 * @default 'jumpbackward'
@@ -95,8 +95,8 @@ const MediaControlsBase = kind({
 		jumpButtonsDisabled: PropTypes.bool,
 
 		/**
-		 * Jump forward [icon]{@link moonstone/Icon.Icon} name. Accepts any
-		 * [icon]{@link moonstone/Icon.Icon} component type.
+		 * Jump forward {@link moonstone/Icon.Icon|icon} name. Accepts any
+		 * {@link moonstone/Icon.Icon|icon} component type.
 		 *
 		 * @type {String}
 		 * @default 'jumpforward'
@@ -254,9 +254,9 @@ const MediaControlsBase = kind({
 
 		/**
 		 * A string which is sent to the `pause` icon of the player controls. This can be
-		 * anything that is accepted by [Icon]{@link moonstone/Icon.Icon}. This will be temporarily replaced by
-		 * the [playIcon]{@link moonstone/VideoPlayer.MediaControls.playIcon} when the
-		 * [paused]{@link moonstone/VideoPlayer.MediaControls.paused} boolean is `false`.
+		 * anything that is accepted by {@link moonstone/Icon.Icon|Icon}. This will be temporarily replaced by
+		 * the {@link moonstone/VideoPlayer.MediaControls.playIcon|playIcon} when the
+		 * {@link moonstone/VideoPlayer.MediaControls.paused|paused} boolean is `false`.
 		 *
 		 * @type {String}
 		 * @default 'pause'
@@ -267,8 +267,8 @@ const MediaControlsBase = kind({
 		/**
 		 * A string which is sent to the `play` icon of the player controls. This can be
 		 * anything that is accepted by {@link moonstone/Icon.Icon}. This will be temporarily replaced by
-		 * the [pauseIcon]{@link moonstone/VideoPlayer.MediaControls.pauseIcon} when the
-		 * [paused]{@link moonstone/VideoPlayer.MediaControls.paused} boolean is `true`.
+		 * the {@link moonstone/VideoPlayer.MediaControls.pauseIcon|pauseIcon} when the
+		 * {@link moonstone/VideoPlayer.MediaControls.paused|paused} boolean is `true`.
 		 *
 		 * @type {String}
 		 * @default 'play'
@@ -639,7 +639,7 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 
 			/**
 			 * Registers the MediaControls component with an
-			 * [ApiDecorator]{@link core/internal/ApiDecorator.ApiDecorator}.
+			 * {@link core/internal/ApiDecorator.ApiDecorator|ApiDecorator}.
 			 *
 			 * @type {Function}
 			 * @private
@@ -917,7 +917,7 @@ const handleCancel = (ev, {onClose}) => {
 /**
  * A set of components for controlling media playback and rendering additional components.
  *
- * This uses [Slottable]{@link ui/Slottable} to accept the custom tags, `<leftComponents>`
+ * This uses {@link ui/Slottable|Slottable} to accept the custom tags, `<leftComponents>`
  * and `<rightComponents>`, to add components to the left and right of the media
  * controls. Any additional children will be rendered into the "more" controls area causing the
  * "more" button to appear. Showing the additional components is handled by `MediaControls` when the

--- a/VideoPlayer/MediaSlider.js
+++ b/VideoPlayer/MediaSlider.js
@@ -9,8 +9,8 @@ import MediaSliderDecorator from './MediaSliderDecorator';
 import css from './VideoPlayer.module.less';
 
 /**
- * The base component to render a customized [Slider]{@link moonstone/Slider.Slider} for use in
- * [VideoPlayer]{@link moonstone/VideoPlayer.VideoPlayer}.
+ * The base component to render a customized {@link moonstone/Slider.Slider|Slider} for use in
+ * {@link moonstone/VideoPlayer.VideoPlayer|VideoPlayer}.
  *
  * @class MediaSliderBase
  * @memberof moonstone/VideoPlayer
@@ -102,7 +102,7 @@ const MediaSliderBase = kind({
 
 /**
  * A customized slider suitable for use within
- * [VideoPlayer]{@link moonstone/VideoPlayer.VideoPlayer}.
+ * {@link moonstone/VideoPlayer.VideoPlayer|VideoPlayer}.
  *
  * @class MediaSlider
  * @memberof moonstone/VideoPlayer

--- a/VideoPlayer/Video.js
+++ b/VideoPlayer/Video.js
@@ -59,7 +59,7 @@ const VideoBase = class extends Component {
 		 * * `pause()` - pause video
 		 * * `load()` - load video
 		 *
-		 * The [`source`]{@link moonstone/VideoPlayer.Video.source} property is passed to
+		 * The {@link moonstone/VideoPlayer.Video.source|source} property is passed to
 		 * the video component as a child node.
 		 *
 		 * @type {String|Component|Element}
@@ -77,7 +77,7 @@ const VideoBase = class extends Component {
 		preloadSource:  PropTypes.node,
 
 		/**
-		 * Called with a reference to the active [Media]{@link ui/Media.Media} component.
+		 * Called with a reference to the active {@link ui/Media.Media|Media} component.
 		 *
 		 * @type {Function}
 		 * @private

--- a/VideoPlayer/VideoPlayer.js
+++ b/VideoPlayer/VideoPlayer.js
@@ -145,7 +145,7 @@ const AnnounceState = {
  */
 
 /**
- * A player for video {@link moonstone/VideoPlayer.VideoPlayerBase}.
+ * A player for video {@link moonstone/VideoPlayer.VideoPlayerBase|VideoPlayerBase}.
  *
  * @class VideoPlayerBase
  * @memberof moonstone/VideoPlayer

--- a/VideoPlayer/VideoPlayer.js
+++ b/VideoPlayer/VideoPlayer.js
@@ -145,7 +145,7 @@ const AnnounceState = {
  */
 
 /**
- * A player for video {@link moonstone/VideoPlayer.VideoPlayerBase|VideoPlayerBase}.
+ * A player for video {@link moonstone/VideoPlayer.VideoPlayerBase}.
  *
  * @class VideoPlayerBase
  * @memberof moonstone/VideoPlayer

--- a/VideoPlayer/VideoPlayer.js
+++ b/VideoPlayer/VideoPlayer.js
@@ -107,7 +107,7 @@ const AnnounceState = {
 };
 
 /**
- * Every callback sent by [VideoPlayer]{@link moonstone/VideoPlayer} receives a status package,
+ * Every callback sent by {@link moonstone/VideoPlayer|VideoPlayer} receives a status package,
  * which includes an object with the following key/value pairs as the first argument:
  *
  * @typedef {Object} videoStatus
@@ -506,7 +506,7 @@ const VideoPlayerBase = class extends Component {
 		/**
 		 * The video source.
 		 *
-		 * Any children `<source>` tag elements of [VideoPlayer]{@link moonstone/VideoPlayer} will
+		 * Any children `<source>` tag elements of {@link moonstone/VideoPlayer|VideoPlayer} will
 		 * be sent directly to the `videoComponent` as video sources.
 		 *
 		 * @type {Node}
@@ -609,7 +609,7 @@ const VideoPlayerBase = class extends Component {
 		 * * `pause()` - pause video
 		 * * `load()` - load video
 		 *
-		 * The [`source`]{@link moonstone/VideoPlayer.Video.source} property is passed to
+		 * The {@link moonstone/VideoPlayer.Video.source|source} property is passed to
 		 * the video component as a child node.
 		 *
 		 * @type {Component|Element}
@@ -1285,7 +1285,7 @@ const VideoPlayerBase = class extends Component {
 
 	/**
 	 * Step a given amount of time away from the current playback position.
-	 * Like [seek]{@link moonstone/VideoPlayer.VideoPlayer#seek} but relative.
+	 * Like {@link moonstone/VideoPlayer.VideoPlayer#seek|seek} but relative.
 	 *
 	 * @function
 	 * @memberof moonstone/VideoPlayer.VideoPlayerBase.prototype
@@ -1306,7 +1306,7 @@ const VideoPlayerBase = class extends Component {
 	};
 
 	/**
-	 * Changes the playback speed via [selectPlaybackRate()]{@link moonstone/VideoPlayer.VideoPlayer#selectPlaybackRate}.
+	 * Changes the playback speed via {@link moonstone/VideoPlayer.VideoPlayer#selectPlaybackRate|selectPlaybackRate()}.
 	 *
 	 * @function
 	 * @memberof moonstone/VideoPlayer.VideoPlayerBase.prototype
@@ -1363,7 +1363,7 @@ const VideoPlayerBase = class extends Component {
 	};
 
 	/**
-	 * Changes the playback speed via [selectPlaybackRate()]{@link moonstone/VideoPlayer.VideoPlayer#selectPlaybackRate}.
+	 * Changes the playback speed via {@link moonstone/VideoPlayer.VideoPlayer#selectPlaybackRate|selectPlaybackRate()}.
 	 *
 	 * @function
 	 * @memberof moonstone/VideoPlayer.VideoPlayerBase.prototype
@@ -1458,7 +1458,7 @@ const VideoPlayerBase = class extends Component {
 	};
 
 	/**
-	 * Sets the playback rate type (from the keys of [playbackRateHash]{@link moonstone/VideoPlayer.VideoPlayer#playbackRateHash}).
+	 * Sets the playback rate type (from the keys of {@link moonstone/VideoPlayer.VideoPlayer#playbackRateHash|playbackRateHash}).
 	 *
 	 * @param {String} cmd - Key of the playback rate type.
 	 * @private
@@ -1468,7 +1468,7 @@ const VideoPlayerBase = class extends Component {
 	};
 
 	/**
-	 * Changes [playbackRate]{@link moonstone/VideoPlayer.VideoPlayer#playbackRate} to a valid value
+	 * Changes {@link moonstone/VideoPlayer.VideoPlayer#playbackRate|playbackRate} to a valid value
 	 * when initiating fast forward or rewind.
 	 *
 	 * @param {Number} idx - The index of the desired playback rate.
@@ -1494,7 +1494,7 @@ const VideoPlayerBase = class extends Component {
 	};
 
 	/**
-	 * Sets [playbackRate]{@link moonstone/VideoPlayer.VideoPlayer#playbackRate}.
+	 * Sets {@link moonstone/VideoPlayer.VideoPlayer#playbackRate|playbackRate}.
 	 *
 	 * @param {String} rate - The desired playback rate.
 	 * @private

--- a/VirtualList/VirtualListBase.js
+++ b/VirtualList/VirtualListBase.js
@@ -36,8 +36,8 @@ const
 	nop = () => {};
 
 /**
- * The base version of [VirtualListBase]{@link moonstone/VirtualList.VirtualListBase} and
- * [VirtualListBaseNative]{@link moonstone/VirtualList.VirtualListBaseNative}.
+ * The base version of {@link moonstone/VirtualList.VirtualListBase|VirtualListBase} and
+ * {@link moonstone/VirtualList.VirtualListBaseNative|VirtualListBaseNative}.
  *
  * @class VirtualListCore
  * @memberof moonstone/VirtualList
@@ -88,7 +88,7 @@ const VirtualListBaseFactory = (type) => {
 
 			/**
 			 * Callback method of scrollTo.
-			 * Normally, [Scrollable]{@link ui/Scrollable.Scrollable} should set this value.
+			 * Normally, {@link ui/Scrollable.Scrollable|Scrollable} should set this value.
 			 *
 			 * @type {Function}
 			 * @private
@@ -139,7 +139,7 @@ const VirtualListBaseFactory = (type) => {
 			focusableScrollbar: PropTypes.bool,
 
 			/**
-			 * Passes the instance of [VirtualList]{@link ui/VirtualList.VirtualList}.
+			 * Passes the instance of {@link ui/VirtualList.VirtualList|VirtualList}.
 			 *
 			 * @type {Object}
 			 * @param {Object} ref
@@ -191,7 +191,7 @@ const VirtualListBaseFactory = (type) => {
 
 			/**
 			 * `true` if rtl, `false` if ltr.
-			 * Normally, [Scrollable]{@link ui/Scrollable.Scrollable} should set this value.
+			 * Normally, {@link ui/Scrollable.Scrollable|Scrollable} should set this value.
 			 *
 			 * @type {Boolean}
 			 * @private
@@ -208,7 +208,7 @@ const VirtualListBaseFactory = (type) => {
 			spacing: PropTypes.number,
 
 			/**
-			 * Spotlight Id. It would be the same with [Scrollable]{@link ui/Scrollable.Scrollable}'s.
+			 * Spotlight Id. It would be the same with {@link ui/Scrollable.Scrollable|Scrollable}'s.
 			 *
 			 * @type {String}
 			 * @private
@@ -859,8 +859,8 @@ const VirtualListBaseFactory = (type) => {
 };
 
 /**
- * A Moonstone-styled base component for [VirtualList]{@link moonstone/VirtualList.VirtualList} and
- * [VirtualGridList]{@link moonstone/VirtualList.VirtualGridList}.
+ * A Moonstone-styled base component for {@link moonstone/VirtualList.VirtualList|VirtualList} and
+ * {@link moonstone/VirtualList.VirtualGridList|VirtualGridList}.
  *
  * @class VirtualListBase
  * @memberof moonstone/VirtualList
@@ -872,8 +872,8 @@ const VirtualListBase = VirtualListBaseFactory(JS);
 VirtualListBase.displayName = 'VirtualListBase';
 
 /**
- * A Moonstone-styled base component for [VirtualListNative]{@link moonstone/VirtualList.VirtualListNative} and
- * [VirtualGridListNative]{@link moonstone/VirtualList.VirtualGridListNative}.
+ * A Moonstone-styled base component for {@link moonstone/VirtualList.VirtualListNative|VirtualListNative} and
+ * {@link moonstone/VirtualList.VirtualGridListNative|VirtualGridListNative}.
  *
  * @class VirtualListBaseNative
  * @memberof moonstone/VirtualList
@@ -898,7 +898,7 @@ VirtualListBaseNative.displayName = 'VirtualListBaseNative';
 /**
  * Unique identifier for the component.
  *
- * When defined and when the `VirtualList` is within a [Panel]{@link moonstone/Panels.Panel},
+ * When defined and when the `VirtualList` is within a {@link moonstone/Panels.Panel|Panel},
  * the `VirtualList` will store its scroll position and restore that position when returning to
  * the `Panel`.
  *

--- a/internal/GridListImageItem/GridListImageItem.js
+++ b/internal/GridListImageItem/GridListImageItem.js
@@ -81,7 +81,7 @@ const GridListImageItem = kind({
 		imageComponent: EnactPropTypes.component,
 
 		/**
-		 * Placeholder image used while [source]{@link moonstone/internal/GridListImageItem.GridListImageItem#source}
+		 * Placeholder image used while {@link moonstone/internal/GridListImageItem.GridListImageItem#source|source}
 		 * is loaded.
 		 *
 		 * @type {String}

--- a/internal/Picker/Picker.js
+++ b/internal/Picker/Picker.js
@@ -87,7 +87,7 @@ const PickerBase = class extends ReactComponent {
 		 * The maximum value selectable by the picker (inclusive).
 		 *
 		 * The range between `min` and `max` should be evenly divisible by
-		 * [step]{@link moonstone/internal/Picker.PickerBase.step}.
+		 * {@link moonstone/internal/Picker.PickerBase.step|step}.
 		 *
 		 * @type {Number}
 		 * @required
@@ -99,7 +99,7 @@ const PickerBase = class extends ReactComponent {
 		 * The minimum value selectable by the picker (inclusive).
 		 *
 		 * The range between `min` and `max` should be evenly divisible by
-		 * [step]{@link moonstone/internal/Picker.PickerBase.step}.
+		 * {@link moonstone/internal/Picker.PickerBase.step|step}.
 		 *
 		 * @type {Number}
 		 * @required
@@ -194,9 +194,9 @@ const PickerBase = class extends ReactComponent {
 		decrementAriaLabel: PropTypes.string,
 
 		/**
-		 * Assign a custom icon for the decrementer. All strings supported by [Icon]{@link moonstone/Icon.Icon} are
+		 * Assign a custom icon for the decrementer. All strings supported by {@link moonstone/Icon.Icon|Icon} are
 		 * supported. Without a custom icon, the default is used, and is automatically changed when
-		 * the [orientation]{@link moonstone/Icon.Icon#orientation} is changed.
+		 * the {@link moonstone/Icon.Icon#orientation|orientation} is changed.
 		 *
 		 * @type {String}
 		 * @public
@@ -205,7 +205,7 @@ const PickerBase = class extends ReactComponent {
 
 		/**
 		 * When `true`, the Picker is shown as disabled and does not generate `onChange`
-		 * [events]{@link /docs/developer-guide/glossary/#event}.
+		 * {@link /docs/developer-guide/glossary/#event|events}.
 		 *
 		 * @type {Boolean}
 		 * @public
@@ -230,9 +230,9 @@ const PickerBase = class extends ReactComponent {
 		incrementAriaLabel: PropTypes.string,
 
 		/**
-		 * Assign a custom icon for the incrementer. All strings supported by [Icon]{@link moonstone/Icon.Icon} are
+		 * Assign a custom icon for the incrementer. All strings supported by {@link moonstone/Icon.Icon|Icon} are
 		 * supported. Without a custom icon, the default is used, and is automatically changed when
-		 * the [orientation]{@link moonstone/Icon.Icon#orientation} is changed.
+		 * the {@link moonstone/Icon.Icon#orientation|orientation} is changed.
 		 *
 		 * @type {String}
 		 * @public


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Adrian Cocoara [adrian.cocoara@lgepartner.com](mailto:adrian.cocoara@lgepartner.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`documentation` module from `docs-utils` has updated to version 14.0.0. In order for the links to be rendered correctly, they have been changed as:
[BodyText]{@link sandstone/BodyText.BodyText}
=> {@link sandstone/BodyText.BodyText|BodyText}

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-13490

### Comments
