### PR TITLE
WRP-14789: Removed `query-string` dependency from Moonstone Storybook

### DIFF
--- a/samples/sampler/package.json
+++ b/samples/sampler/package.json
@@ -27,7 +27,6 @@
     "@enact/ui": "^4.6.2",
     "classnames": "^2.3.2",
     "ilib": "^14.17.0",
-    "query-string": "^7.1.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Checked if query-string is used in moonstone storybook and removed it as it is not used.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Removed query-string dependency from sampler/package.json.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-14789

### Comments
Enact-DCO-1.0-Signed-off-by: Andrei Tirla andrei.tirla@lgepartner.com
